### PR TITLE
Update trigger for PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,8 @@ on:
   push:
     branches:
       - main
-  pull_request_target:
-    branches:
-      - main
+  pull_request:
+    types: [opened, reopened]
 
 jobs:
   pre-commit:

--- a/src/python/setup.py
+++ b/src/python/setup.py
@@ -133,14 +133,14 @@ def deepgnn_tf(version: str):
 def deepgnn_pytorch(version: str):
     """DeepGNN runtime and algorithms for pytorch."""
     depens = [
-            "deepgnn-ge>=0.1",
-            "torch>=1.8",
-            "boto3>=1.15.16",
-            "transformers>=4.3.3",
-            "sentencepiece>=0.1.95",
-            "tqdm>=4.51.0",
-        ]
-    )
+        "deepgnn-ge>=0.1",
+        "torch>=1.8",
+        "boto3>=1.15.16",
+        "transformers>=4.3.3",
+        "sentencepiece>=0.1.95",
+        "tqdm>=4.51.0",
+    ]
+
     depens.extend(COMMON_PACKAGES)
 
     setuptools.setup(


### PR DESCRIPTION
Fix branch used in the checkout, use [pull_request](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request) to have `GITHUB_SHA` set to last merge commit on the `GITHUB_REF` branch(which is read by checkout action) instead of [pull_request_target](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target).