### PR TITLE
make the logger customized with set logger function

### DIFF
--- a/src/python/deepgnn/__init__.py
+++ b/src/python/deepgnn/__init__.py
@@ -34,5 +34,6 @@ from .logging_utils import (
     get_current_user,
     log_telemetry,
     get_logger,
+    set_logger,
     setup_default_logging_config,
 )

--- a/src/python/deepgnn/logging_utils.py
+++ b/src/python/deepgnn/logging_utils.py
@@ -127,7 +127,7 @@ def setup_default_logging_config(enable_telemetry: bool = False):
 
 
 def set_logger(customized_logger: logging.Logger) -> None:
-    ''' client could provide the contomized logger.
+    ''' client could provide the customized logger.
 
     This function will override the underlying logger `_logger`.
     '''

--- a/src/python/deepgnn/logging_utils.py
+++ b/src/python/deepgnn/logging_utils.py
@@ -126,6 +126,22 @@ def setup_default_logging_config(enable_telemetry: bool = False):
     _init = True
 
 
+def set_logger(customized_logger: logging.Logger) -> None:
+    ''' client could provide the contomized logger.
+
+    This function will override the underlying logger `_logger`.
+    '''
+    global _logger
+
+    _logger_lock.acquire()
+
+    try:
+        _logger = customized_logger
+
+    finally:
+        _logger_lock.release()
+
+
 def get_logger():
     global _logger
     global _init


### PR DESCRIPTION
make the logger customized with set logger function

we have two options to make customized logger:
1. client makes changes to LOGGING
2. create new set_logger function which allows client to pass customized logger

in this PR, we are implementing the second one. 