### PR TITLE
Implement features with variable length

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
   pull_request:
-    types: [opened, reopened]
+    types: [opened, reopened, synchronize]
 
 jobs:
   pre-commit:

--- a/src/cc/lib/distributed/call_data.cc
+++ b/src/cc/lib/distributed/call_data.cc
@@ -328,4 +328,61 @@ void EdgeSparseFeaturesCallData::Proceed()
     }
 }
 
+NodeStringFeaturesCallData::NodeStringFeaturesCallData(GraphEngine::AsyncService &service,
+                                                       grpc::ServerCompletionQueue &cq,
+                                                       snark::GraphEngine::Service &service_impl)
+    : CallData(cq), m_responder(&m_ctx), m_service_impl(service_impl), m_service(service)
+{
+    Proceed();
+}
+
+void NodeStringFeaturesCallData::Proceed()
+{
+    if (m_status == CREATE)
+    {
+        m_status = PROCESS;
+        m_service.RequestGetNodeStringFeatures(&m_ctx, &m_request, &m_responder, &m_cq, &m_cq, this);
+    }
+    else if (m_status == PROCESS)
+    {
+        new NodeStringFeaturesCallData(m_service, m_cq, m_service_impl);
+        const auto status = m_service_impl.GetNodeStringFeatures(&m_ctx, &m_request, &m_reply);
+        m_status = FINISH;
+        m_responder.Finish(m_reply, status, this);
+    }
+    else
+    {
+        GPR_ASSERT(m_status == FINISH);
+        delete this;
+    }
+}
+
+EdgeStringFeaturesCallData::EdgeStringFeaturesCallData(GraphEngine::AsyncService &service,
+                                                       grpc::ServerCompletionQueue &cq,
+                                                       snark::GraphEngine::Service &service_impl)
+    : CallData(cq), m_responder(&m_ctx), m_service_impl(service_impl), m_service(service)
+{
+    Proceed();
+}
+
+void EdgeStringFeaturesCallData::Proceed()
+{
+    if (m_status == CREATE)
+    {
+        m_status = PROCESS;
+        m_service.RequestGetEdgeStringFeatures(&m_ctx, &m_request, &m_responder, &m_cq, &m_cq, this);
+    }
+    else if (m_status == PROCESS)
+    {
+        new EdgeStringFeaturesCallData(m_service, m_cq, m_service_impl);
+        m_service_impl.GetEdgeStringFeatures(&m_ctx, &m_request, &m_reply);
+        m_status = FINISH;
+        m_responder.Finish(m_reply, grpc::Status::OK, this);
+    }
+    else
+    {
+        GPR_ASSERT(m_status == FINISH);
+        delete this;
+    }
+}
 } // namespace snark

--- a/src/cc/lib/distributed/call_data.h
+++ b/src/cc/lib/distributed/call_data.h
@@ -215,5 +215,36 @@ class EdgeSparseFeaturesCallData final : public CallData
     GraphEngine::AsyncService &m_service;
 };
 
+class NodeStringFeaturesCallData final : public CallData
+{
+  public:
+    NodeStringFeaturesCallData(GraphEngine::AsyncService &service, grpc::ServerCompletionQueue &cq,
+                               snark::GraphEngine::Service &service_impl);
+
+    void Proceed() override;
+
+  private:
+    NodeSparseFeaturesRequest m_request;
+    StringFeaturesReply m_reply;
+    grpc::ServerAsyncResponseWriter<StringFeaturesReply> m_responder;
+    snark::GraphEngine::Service &m_service_impl;
+    GraphEngine::AsyncService &m_service;
+};
+
+class EdgeStringFeaturesCallData final : public CallData
+{
+  public:
+    EdgeStringFeaturesCallData(GraphEngine::AsyncService &service, grpc::ServerCompletionQueue &cq,
+                               snark::GraphEngine::Service &service_impl);
+
+    void Proceed() override;
+
+  private:
+    EdgeSparseFeaturesRequest m_request;
+    StringFeaturesReply m_reply;
+    grpc::ServerAsyncResponseWriter<StringFeaturesReply> m_responder;
+    snark::GraphEngine::Service &m_service_impl;
+    GraphEngine::AsyncService &m_service;
+};
 } // namespace snark
 #endif

--- a/src/cc/lib/distributed/client.h
+++ b/src/cc/lib/distributed/client.h
@@ -40,6 +40,13 @@ class GRPCClient final
                               std::span<int64_t> out_dimensions, std::vector<std::vector<int64_t>> &out_indices,
                               std::vector<std::vector<uint8_t>> &out_values);
 
+    void GetNodeStringFeature(std::span<const NodeId> node_ids, std::span<const FeatureId> features,
+                              std::span<int64_t> out_dimensions, std::vector<uint8_t> &out_values);
+
+    void GetEdgeStringFeature(std::span<const NodeId> edge_src_ids, std::span<const NodeId> edge_dst_ids,
+                              std::span<const Type> edge_types, std::span<const FeatureId> features,
+                              std::span<int64_t> out_dimensions, std::vector<uint8_t> &out_values);
+
     void FullNeighbor(std::span<const NodeId> node_ids, std::span<const Type> edge_types,
                       std::vector<NodeId> &output_nodes, std::vector<Type> &output_types,
                       std::vector<float> &output_weights, std::span<uint64_t> output_neighbor_counts);

--- a/src/cc/lib/distributed/graph_engine.h
+++ b/src/cc/lib/distributed/graph_engine.h
@@ -30,6 +30,10 @@ class GraphEngineServiceImpl final : public snark::GraphEngine::Service
                                        snark::SparseFeaturesReply *response) override;
     grpc::Status GetEdgeSparseFeatures(::grpc::ServerContext *context, const snark::EdgeSparseFeaturesRequest *request,
                                        snark::SparseFeaturesReply *response) override;
+    grpc::Status GetNodeStringFeatures(::grpc::ServerContext *context, const snark::NodeSparseFeaturesRequest *request,
+                                       snark::StringFeaturesReply *response) override;
+    grpc::Status GetEdgeStringFeatures(::grpc::ServerContext *context, const snark::EdgeSparseFeaturesRequest *request,
+                                       snark::StringFeaturesReply *response) override;
     grpc::Status GetNeighbors(::grpc::ServerContext *context, const snark::GetNeighborsRequest *request,
                               snark::GetNeighborsReply *response) override;
     grpc::Status WeightedSampleNeighbors(::grpc::ServerContext *context,

--- a/src/cc/lib/distributed/server.cc
+++ b/src/cc/lib/distributed/server.cc
@@ -71,6 +71,18 @@ class EmptyGraphEngine final : public snark::GraphEngine::Service
         return grpc::Status::OK;
     }
 
+    grpc::Status GetNodeStringFeatures(::grpc::ServerContext *context, const snark::NodeSparseFeaturesRequest *request,
+                                       snark::StringFeaturesReply *response) override
+    {
+        return grpc::Status::OK;
+    }
+
+    grpc::Status GetEdgeStringFeatures(::grpc::ServerContext *context, const snark::EdgeSparseFeaturesRequest *request,
+                                       snark::StringFeaturesReply *response) override
+    {
+        return grpc::Status::OK;
+    }
+
     grpc::Status GetNeighbors(::grpc::ServerContext *context, const snark::GetNeighborsRequest *request,
                               snark::GetNeighborsReply *response) override
     {
@@ -168,6 +180,8 @@ void GRPCServer::HandleRpcs(size_t index)
         new EdgeFeaturesCallData(m_engine_service, queue, *m_engine_service_impl);
         new NodeSparseFeaturesCallData(m_engine_service, queue, *m_engine_service_impl);
         new EdgeSparseFeaturesCallData(m_engine_service, queue, *m_engine_service_impl);
+        new NodeStringFeaturesCallData(m_engine_service, queue, *m_engine_service_impl);
+        new EdgeStringFeaturesCallData(m_engine_service, queue, *m_engine_service_impl);
         new GetMetadataCallData(m_engine_service, queue, *m_engine_service_impl);
         new NodeTypesCallData(m_engine_service, queue, *m_engine_service_impl);
     }

--- a/src/cc/lib/distributed/service.proto
+++ b/src/cc/lib/distributed/service.proto
@@ -11,6 +11,8 @@ service GraphEngine {
   rpc GetEdgeFeatures (EdgeFeaturesRequest) returns (EdgeFeaturesReply) {}
   rpc GetNodeSparseFeatures (NodeSparseFeaturesRequest) returns (SparseFeaturesReply) {}
   rpc GetEdgeSparseFeatures (EdgeSparseFeaturesRequest) returns (SparseFeaturesReply) {}
+  rpc GetNodeStringFeatures (NodeSparseFeaturesRequest) returns (StringFeaturesReply) {}
+  rpc GetEdgeStringFeatures (EdgeSparseFeaturesRequest) returns (StringFeaturesReply) {}
 
   rpc GetNeighbors (GetNeighborsRequest) returns (GetNeighborsReply) {}
 
@@ -139,6 +141,11 @@ message SparseFeaturesReply {
   repeated int64 dimensions = 3;
   repeated int64 indices_counts = 4;
   repeated int64 values_counts = 5;
+}
+
+message StringFeaturesReply {
+  bytes values = 1;
+  repeated int64 dimensions = 2;
 }
 
 message GetNeighborsRequest {

--- a/src/cc/lib/graph/graph.h
+++ b/src/cc/lib/graph/graph.h
@@ -25,12 +25,18 @@ class Graph
   public:
     Graph(std::string path, std::vector<uint32_t> partitions, PartitionStorageType storage_type,
           std::string config_path);
+
     void GetNodeType(std::span<const NodeId> node_ids, std::span<Type> output, Type default_type) const;
+
     void GetNodeFeature(std::span<const NodeId> node_ids, std::span<snark::FeatureMeta> features,
                         std::span<uint8_t> output) const;
+
     void GetNodeSparseFeature(std::span<const NodeId> node_ids, std::span<const snark::FeatureId> features,
                               std::span<int64_t> out_dimensions, std::vector<std::vector<int64_t>> &out_indices,
                               std::vector<std::vector<uint8_t>> &out_data) const;
+
+    void GetNodeStringFeature(std::span<const NodeId> node_ids, std::span<const snark::FeatureId> features,
+                              std::span<int64_t> out_dimensions, std::vector<uint8_t> &out_data) const;
 
     void GetEdgeFeature(std::span<const NodeId> input_edge_src, std::span<const NodeId> input_edge_dst,
                         std::span<const Type> input_edge_type, std::span<snark::FeatureMeta> features,
@@ -40,6 +46,10 @@ class Graph
                               std::span<const Type> input_edge_type, std::span<const snark::FeatureId> features,
                               std::span<int64_t> out_dimensions, std::vector<std::vector<int64_t>> &out_indices,
                               std::vector<std::vector<uint8_t>> &out_values) const;
+
+    void GetEdgeStringFeature(std::span<const NodeId> input_edge_src, std::span<const NodeId> input_edge_dst,
+                              std::span<const Type> input_edge_type, std::span<const snark::FeatureId> features,
+                              std::span<int64_t> out_dimensions, std::vector<uint8_t> &out_values) const;
 
     void FullNeighbor(std::span<const NodeId> input_node_ids, std::span<const Type> input_edge_types,
                       std::vector<NodeId> &output_neighbor_ids, std::vector<Type> &output_neighbor_types,

--- a/src/cc/lib/graph/partition.h
+++ b/src/cc/lib/graph/partition.h
@@ -32,6 +32,9 @@ struct Partition
                               std::span<int64_t> out_dimensions, std::vector<std::vector<int64_t>> &out_indices,
                               std::vector<std::vector<uint8_t>> &out_values) const;
 
+    void GetNodeStringFeature(uint64_t internal_node_id, std::span<const snark::FeatureId> features,
+                              std::span<int64_t> out_dimensions, std::vector<uint8_t> &out_values) const;
+
     // Return true if an edge was found in the partition
     bool GetEdgeFeature(uint64_t internal_src_node_id, NodeId input_edge_dst, Type input_edge_type,
                         std::span<snark::FeatureMeta> features, std::span<uint8_t> output) const;
@@ -40,6 +43,10 @@ struct Partition
                               std::span<const snark::FeatureId> features, int64_t prefix,
                               std::span<int64_t> out_dimensions, std::vector<std::vector<int64_t>> &out_indices,
                               std::vector<std::vector<uint8_t>> &out_values) const;
+
+    bool GetEdgeStringFeature(uint64_t internal_src_node_id, NodeId input_edge_dst, Type input_edge_type,
+                              std::span<const snark::FeatureId> features, std::span<int64_t> out_dimensions,
+                              std::vector<uint8_t> &out_values) const;
 
     // Backfill out_* vectors with information about neighbors of the node
     // with id equal to node_id and returns total number of such neighbors.

--- a/src/cc/lib/py_graph.cc
+++ b/src/cc/lib/py_graph.cc
@@ -383,7 +383,6 @@ int32_t GetNodeSparseFeature(PyGraph *py_graph, NodeID *node_ids, size_t node_id
     }
     else
     {
-
         try
         {
             py_graph->graph->client->GetNodeSparseFeature(
@@ -412,6 +411,41 @@ int32_t GetNodeSparseFeature(PyGraph *py_graph, NodeID *node_ids, size_t node_id
     }
 
     callback(indices_ptrs.data(), indices_sizes.data(), data_ptrs.data(), data_sizes.data(), dimensions.data());
+    return 0;
+}
+
+int32_t GetNodeStringFeature(PyGraph *py_graph, NodeID *node_ids, size_t node_ids_size, Feature *features,
+                             size_t features_size, int64_t *dimensions, GetStringFeaturesCallback callback)
+{
+    if (py_graph->graph == nullptr)
+    {
+        RAW_LOG_ERROR("Internal graph is not initialized");
+        return 1;
+    }
+
+    std::vector<uint8_t> data;
+    if (py_graph->graph->graph)
+    {
+        py_graph->graph->graph->GetNodeStringFeature(
+            std::span(reinterpret_cast<snark::NodeId *>(node_ids), node_ids_size), std::span(features, features_size),
+            std::span(dimensions, node_ids_size * features_size), data);
+    }
+    else
+    {
+        try
+        {
+            py_graph->graph->client->GetNodeStringFeature(
+                std::span(reinterpret_cast<snark::NodeId *>(node_ids), node_ids_size),
+                std::span(features, features_size), std::span(dimensions, node_ids_size * features_size), data);
+        }
+        catch (const std::exception &e)
+        {
+            RAW_LOG_ERROR("Exception while fetching node features: %s", e.what());
+            return 1;
+        }
+    }
+
+    callback(data.size(), data.data());
     return 0;
 }
 
@@ -504,6 +538,47 @@ int32_t GetEdgeSparseFeature(PyGraph *py_graph, NodeID *edge_src_ids, NodeID *ed
     }
 
     callback(indices_ptrs.data(), indices_sizes.data(), data_ptrs.data(), data_sizes.data(), dimensions.data());
+    return 0;
+}
+
+int32_t GetEdgeStringFeature(PyGraph *py_graph, NodeID *edge_src_ids, NodeID *edge_dst_ids, Type *edge_types,
+                             size_t edge_size, Feature *features, size_t features_size, int64_t *dimensions,
+                             GetStringFeaturesCallback callback)
+{
+    if (py_graph->graph == nullptr)
+    {
+        RAW_LOG_ERROR("Internal graph is not initialized");
+        return 1;
+    }
+
+    std::vector<uint8_t> data;
+    if (py_graph->graph->graph)
+    {
+        py_graph->graph->graph->GetEdgeStringFeature(
+            std::span(reinterpret_cast<snark::NodeId *>(edge_src_ids), edge_size),
+            std::span(reinterpret_cast<snark::NodeId *>(edge_dst_ids), edge_size),
+            std::span(reinterpret_cast<snark::Type *>(edge_types), edge_size), std::span(features, features_size),
+            std::span(dimensions, features_size * edge_size), data);
+    }
+
+    else
+    {
+        try
+        {
+            py_graph->graph->client->GetEdgeStringFeature(
+                std::span(reinterpret_cast<snark::NodeId *>(edge_src_ids), edge_size),
+                std::span(reinterpret_cast<snark::NodeId *>(edge_dst_ids), edge_size),
+                std::span(reinterpret_cast<snark::Type *>(edge_types), edge_size), std::span(features, features_size),
+                std::span(dimensions, features_size * edge_size), data);
+        }
+        catch (const std::exception &e)
+        {
+            RAW_LOG_ERROR("Exception while fetching node features: %s", e.what());
+            return 1;
+        }
+    }
+
+    callback(data.size(), data.data());
     return 0;
 }
 

--- a/src/cc/lib/py_graph.h
+++ b/src/cc/lib/py_graph.h
@@ -74,6 +74,7 @@ extern "C"
 
     typedef void (*GetNeighborsCallback)(const NodeID *, const float *, const Type *, size_t);
     typedef void (*GetSparseFeaturesCallback)(const int64_t **, size_t *, const uint8_t **, size_t *, int64_t *);
+    typedef void (*GetStringFeaturesCallback)(size_t, const uint8_t *);
 
     DEEPGNN_DLL extern int32_t CreateLocalGraph(PyGraph *graph, size_t count, uint32_t *partitions,
                                                 const char *filename, PyPartitionStorageType storage_type,
@@ -95,12 +96,19 @@ extern "C"
     DEEPGNN_DLL extern int32_t GetNodeSparseFeature(PyGraph *graph, NodeID *node_ids, size_t node_ids_size,
                                                     Feature *features, size_t features_size,
                                                     GetSparseFeaturesCallback callback);
+    DEEPGNN_DLL extern int32_t GetNodeStringFeature(PyGraph *graph, NodeID *node_ids, size_t node_ids_size,
+                                                    Feature *features, size_t features_size, int64_t *dimensions,
+                                                    GetStringFeaturesCallback callback);
     DEEPGNN_DLL extern int32_t GetEdgeFeature(PyGraph *graph, NodeID *edge_src_ids, NodeID *edge_dst_ids,
                                               Type *edge_types, size_t edge_size, Feature *features,
                                               size_t features_size, uint8_t *output, size_t output_size);
     DEEPGNN_DLL extern int32_t GetEdgeSparseFeature(PyGraph *graph, NodeID *edge_src_ids, NodeID *edge_dst_ids,
                                                     Type *edge_types, size_t edge_size, Feature *features,
                                                     size_t features_size, GetSparseFeaturesCallback callback);
+    DEEPGNN_DLL extern int32_t GetEdgeStringFeature(PyGraph *graph, NodeID *edge_src_ids, NodeID *edge_dst_ids,
+                                                    Type *edge_types, size_t edge_size, Feature *features,
+                                                    size_t features_size, int64_t *dimensions,
+                                                    GetStringFeaturesCallback callback);
     DEEPGNN_DLL extern int32_t GetNeighbors(PyGraph *graph, NodeID *in_node_ids, size_t in_node_ids_size,
                                             Type *in_edge_types, size_t in_edge_types_size,
                                             uint64_t *out_neighbor_counts, GetNeighborsCallback callback);

--- a/src/cc/lib/version-script.darwin.lds
+++ b/src/cc/lib/version-script.darwin.lds
@@ -5,8 +5,10 @@ _StartServer
 _CreateRemoteClient
 _GetNodeFeature
 _GetNodeSparseFeature
+_GetNodeStringFeature
 _GetEdgeFeature
 _GetEdgeSparseFeature
+_GetEdgeStringFeature
 _StartServer
 _GetNeighbors
 _WeightedSampleNeighbor

--- a/src/cc/lib/version-script.linux.lds
+++ b/src/cc/lib/version-script.linux.lds
@@ -7,8 +7,10 @@
         CreateRemoteClient;
         GetNodeFeature;
         GetNodeSparseFeature;
+        GetNodeStringFeature;
         GetEdgeFeature;
         GetEdgeSparseFeature;
+        GetEdgeStringFeature;
         StartServer;
         GetNeighbors;
         WeightedSampleNeighbor;


### PR DESCRIPTION
The code is very similar to dense features, extracting features through index look ups, but without back fills.
The major difference, however, is we don't know feature dimensions in advance and can't pre-allocate arrays in Python. This means we need to use callbacks from C++(`py_data.cc`) that will tell python interpreter(`_StringFeatureCallback`) where to copy data from when all features are fetched from graph engine.
