### PR TITLE
Converter accept linear input format

### DIFF
--- a/src/python/deepgnn/graph_engine/snark/BUILD
+++ b/src/python/deepgnn/graph_engine/snark/BUILD
@@ -16,7 +16,7 @@ py_library(
         "convert.py",
         "meta_merger.py",
         "converter/__init__.py",
-        "converter/json_converter.py",
+        "converter/converter.py",
         "converter/options.py",
         "decoders.py",
         "dispatcher.py",

--- a/src/python/deepgnn/graph_engine/snark/convert.py
+++ b/src/python/deepgnn/graph_engine/snark/convert.py
@@ -120,7 +120,6 @@ def output(
                 ctypes.c_uint64(edge_writer.ei.tell() // (4 + 8 + 8 + 4))
             )  # 4 bytes type, 8 bytes destination, 8 bytes offset, 4 bytes weight
 
-
             edge_list = sorted(
                 node["edge"], key=lambda x: (int(x["edge_type"]), int(x["dst_id"]))
             )
@@ -152,20 +151,18 @@ def output(
 
                 node_alias.add(node)
 
-                node_count += 1
 
                 node_weight[node["node_type"]] += float(node["node_weight"])
                 node_type_count[node["node_type"]] += 1
 
-            # edge_list = sorted(
-            #     node["edge"], key=lambda x: (int(x["edge_type"]), int(x["dst_id"]))
-            # )
+                node_count += 1
             else:
+                edge = item
                 edge_writer.add(edge)
 
-                edge_alias.add(eet)
-                edge_weight[eet["edge_type"]] += eet["weight"]
-                edge_type_count[eet["edge_type"]] += 1
+                edge_alias.add(edge)
+                edge_weight[edge["edge_type"]] += edge["weight"]
+                edge_type_count[edge["edge_type"]] += 1
 
                 edge_count += 1
 
@@ -261,10 +258,7 @@ class MultiWorkersConverter:
                 output,
                 self.decoder_type,
                 self.partition_offset,
-                False
-                if hasattr(fsspec.implementations, "hdfs")
-                and isinstance(self.fs, fsspec.implementations.hdfs.PyArrowHDFS)
-                else True,  # when converting data in HDFS make sure to turn it off: https://hdfs3.readthedocs.io/en/latest/limitations.html
+                True,
                 skip_node_sampler,
                 skip_edge_sampler,
             )

--- a/src/python/deepgnn/graph_engine/snark/convert.py
+++ b/src/python/deepgnn/graph_engine/snark/convert.py
@@ -116,6 +116,7 @@ def output(
 
             # Works if sorted Node, src edge, ... Nodei+1
             import ctypes
+
             edge_writer.nbi.write(  # type: ignore
                 ctypes.c_uint64(edge_writer.ei.tell() // (4 + 8 + 8 + 4))
             )  # 4 bytes type, 8 bytes destination, 8 bytes offset, 4 bytes weight
@@ -146,6 +147,7 @@ def output(
                     node_writer.add(node)
 
                     import ctypes
+
                     edge_writer.nbi.write(  # type: ignore
                         ctypes.c_uint64(edge_writer.ei.tell() // (4 + 8 + 8 + 4))
                     )  # 4 bytes type, 8 bytes destination, 8 bytes offset, 4 bytes weight
@@ -258,7 +260,10 @@ class MultiWorkersConverter:
                 output,
                 self.decoder_type,
                 self.partition_offset,
-                True,
+                False
+                if hasattr(fsspec.implementations, "hdfs")
+                and isinstance(self.fs, fsspec.implementations.hdfs.PyArrowHDFS)
+                else True,  # when converting data in HDFS make sure to turn it off: https://hdfs3.readthedocs.io/en/latest/limitations.html
                 skip_node_sampler,
                 skip_edge_sampler,
             )
@@ -291,7 +296,7 @@ class MultiWorkersConverter:
 
                 if self.decoder_type == DecoderType.LINEAR:
                     i = line.find(" ")
-                    if line[i+1:i+3] == "-1":  # if line is node
+                    if line[i + 1 : i + 3] == "-1":  # if line is node
                         if len(lines):
                             d.dispatch(lines)
                         lines = []

--- a/src/python/deepgnn/graph_engine/snark/convert.py
+++ b/src/python/deepgnn/graph_engine/snark/convert.py
@@ -143,14 +143,12 @@ def output(
                 node = item
                 node_writer.add(node)
 
-                # Works if sorted Node, src edge, ... Nodei+1
                 import ctypes
                 edge_writer.nbi.write(  # type: ignore
                     ctypes.c_uint64(edge_writer.ei.tell() // (4 + 8 + 8 + 4))
                 )  # 4 bytes type, 8 bytes destination, 8 bytes offset, 4 bytes weight
 
                 node_alias.add(node)
-
 
                 node_weight[node["node_type"]] += float(node["node_weight"])
                 node_type_count[node["node_type"]] += 1

--- a/src/python/deepgnn/graph_engine/snark/convert.py
+++ b/src/python/deepgnn/graph_engine/snark/convert.py
@@ -291,17 +291,16 @@ class MultiWorkersConverter:
         )
 
         lines = []
+        not_first = False
         for _, data in enumerate(dataset):
             for line in data:
-
                 if self.decoder_type == DecoderType.LINEAR:
-                    i = line.find(" ")
-                    if line[i + 1 : i + 3] == "-1":  # if line is node
-                        if len(lines):
+                    if line[0] == "-":  # if line is node
+                        if not_first:
                             d.dispatch(lines)
                         lines = []
+                        not_first = True
                     lines.append(line)
-
                 else:
                     d.dispatch(line)
 

--- a/src/python/deepgnn/graph_engine/snark/converter/converter.py
+++ b/src/python/deepgnn/graph_engine/snark/converter/converter.py
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-"""Set of writers to convert graph from json format to binary."""
+"""Set of writers to convert graph from linar format to binary."""
 import ctypes
 import os
 import tempfile

--- a/src/python/deepgnn/graph_engine/snark/decoders.py
+++ b/src/python/deepgnn/graph_engine/snark/decoders.py
@@ -211,13 +211,14 @@ class LinearDecoder(Decoder):
     def __init__(self):
         """Initialize the Decoder."""
         super().__init__()
-        definition = r"((?P<src>-1|\d+) (?P<dst>\d+) (?P<type>\d+) (?P<weight>[+-]?([0-9]+([.][0-9]*)?|[.][0-9]+))(?P<features>( (uint64|float)_feature\/[0-9]*\/([+-]?([0-9]+([.][0-9]*)?|[.][0-9]+),)*[+-]?([0-9]+([.][0-9]*)?|[.][0-9]+))*))"
+        definition = r"(-1|\d+) (\d+) (\d+) ([-]?(?:[0-9]+(?:[.][0-9]*)?|[.][0-9]+))((?: (?:uint64|float)_feature\/[0-9]*\/(?:[-]?(?:[0-9]+(?:[.][0-9]*)?|[.][0-9]+),)*[-]?(?:[0-9]+(?:[.][0-9]*)?|[.][0-9]+))*)"
         self.pattern = re.compile(definition)
 
     def decode(self, line: str):
         """Use json package to convert the json text line into node object."""
         groups = self.pattern.match(line)
-        src, dst, typ, weight, features = groups.group("src", "dst", "type", "weight", "features")
+        #print(groups.groups())
+        src, dst, typ, weight, features = groups.groups()
         #print(line, groups, src, dst, type, weight, features)
         #if src is None:
         #    exit()

--- a/src/python/deepgnn/graph_engine/snark/decoders.py
+++ b/src/python/deepgnn/graph_engine/snark/decoders.py
@@ -203,7 +203,7 @@ class LinearDecoder(Decoder):
     def decode(self, line: str):
         """Use json package to convert the json text line into node object."""
         src, dst, type, weight, features = line.split()
-        if dst == -1:  # is node
+        if int(dst) == -1:  # is node
             output = {
                 "node_id": int(src),
                 "node_type": int(type),
@@ -222,9 +222,6 @@ class LinearDecoder(Decoder):
                 "weight": float(weight),
             }
             output.update(json.loads(features))
-            #"uint64_feature": {"feature id": ["int", "..."], "...": ["int", "..."]},
-            #"float_feature": {"feature id": ["float", "..."], "...": ["float", "..."]},
-            #"binary_feature": {"feature id": "string", "...": "..."},
             #"sparse_int32_feature": {"feature id": {"coordinates": [["non zero coordinates 0"], ["non zero coordinates 1", "..."]], "values": ["value 0", "value 1", "..."]}},
 
         return output
@@ -239,15 +236,16 @@ def json_to_linear(filename_in, filename_out):
 
         # TODO sparse features
 
-        features = str({key: node[key] for key in ["uint64_feature", "float_feature", "binary_feature"]}).replace(" ", "")
-        file_out.write(f'{node["node_id"]} -1 {node["node_type"]} {node["node_weight"]} {features}')
+        features = json.dumps({key: node[key] for key in ["uint64_feature", "float_feature", "binary_feature"]}).replace(" ", "")
+        file_out.write(f'{node["node_id"]} -1 {node["node_type"]} {node["node_weight"]} {features}\n')
 
         edge_list = sorted(
              node["edge"], key=lambda x: (int(x["edge_type"]), int(x["dst_id"]))
         )
         for edge in edge_list:
-            features = str({key: edge[key] for key in ["uint64_feature", "float_feature", "binary_feature"]}).replace(" ", "")
-            file_out.write(f'{edge["src_id"]} {edge["dst_id"]} {edge["edge_type"]} {edge["weight"]} {features}')
+            features = json.dumps({key: edge[key] for key in ["uint64_feature", "float_feature", "binary_feature"]}).replace(" ", "")
+            file_out.write(f'{edge["src_id"]} {edge["dst_id"]} {edge["edge_type"]} {edge["weight"]} {features}\n')
+            print(edge["edge_type"])
 
     file_in.close()
     file_out.close()

--- a/src/python/deepgnn/graph_engine/snark/decoders.py
+++ b/src/python/deepgnn/graph_engine/snark/decoders.py
@@ -220,12 +220,7 @@ class LinearDecoder(Decoder):
                 "node_type": int(type),
                 "node_weight": float(weight),
             }
-            for feature in features:
-                key, idx, value = feature.split("/")
-                if key not in output:
-                    output[key] = {}
-                output[key][idx] = list(map(float if '.' in value else int, value.split(",")))
-            # ignores neighbors
+            _load_features(output, features)
         else:  # is edge
             output = {
                 "src_id": int(src),
@@ -233,13 +228,28 @@ class LinearDecoder(Decoder):
                 "edge_type": int(type),
                 "weight": float(weight),
             }
-            for feature in features:
-                key, idx, value = feature.split("/")
-                if key not in output:
-                    output[key] = {}
-                output[key][idx] = list(map(float if '.' in value else int, value.split(",")))
+            _load_features(output, features)
 
         return output
+
+
+convert_map = {  # TODO all + sparse
+    "float_feature": float,
+    "uint64_feature": int,
+    "binary_feature": lambda x: x,
+}
+
+def _load_features(output, features):
+    for feature in features:
+        key, idx, value = feature.split("/")
+        if key not in output:
+            output[key] = {}
+        
+
+        if key == "binary_feature":
+            output[key][idx] = value.replace(",", "")
+        else:
+            output[key][idx] = list(map(convert_map[key], value.split(",")))
 
 
 def _dump_features(features: dict) -> str:

--- a/src/python/deepgnn/graph_engine/snark/decoders.py
+++ b/src/python/deepgnn/graph_engine/snark/decoders.py
@@ -241,7 +241,61 @@ def json_to_linear(filename_in, filename_out):
         )
         for edge in edge_list:
             file_out.write(f'{edge["src_id"]} {edge["dst_id"]} {edge["edge_type"]} {edge["weight"]} {_dump_features(edge)}\n')
-            print(edge["edge_type"])
 
     file_in.close()
     file_out.close()
+
+
+def src_sort(filename_in, filename_out):
+    file_in = open(filename_in, 'r')
+    file_out = open(filename_out, 'w')
+
+    lines = {}
+    for line in file_in.readlines():
+        src, dst, *_ = line.split()
+        src, dst = int(src), int(dst)
+        if src not in lines:
+            lines[src] = []
+        lines[src].append((src, dst, line))
+
+    for (key, values) in sorted(lines.items()):
+        for line in sorted(values, key=lambda v: v[1]):
+            file_out.write(line[2])
+
+    file_in.close()
+    file_out.close()
+
+
+def dst_sort(filename_in, filename_out):
+    file_in = open(filename_in, 'r')
+    file_out = open(filename_out, 'w')
+
+    lines = {}
+    for line in file_in.readlines():
+        src, dst, *_ = line.split()
+        src, dst = int(src), int(dst)
+        if dst == -1:
+            dst = src
+            src = -1
+        if dst not in lines:
+            lines[dst] = []
+        lines[dst].append((src, dst, line))
+
+    for (key, values) in sorted(lines.items()):
+        for line in sorted(values, key=lambda v: v[0]):
+            file_out.write(line[2])
+
+    file_in.close()
+    file_out.close()
+
+
+if __name__ == '__main__':
+    file_in = "/tmp/ppi/graph.json"
+    file_out = "/tmp/ppi/graph.linear"
+    file_src = "/tmp/ppi/graph_src.linear"
+    file_dst = "/tmp/ppi/graph_dst.linear"
+
+    #json_to_linear(file_in, file_out)
+
+    src_sort(file_out, file_src)
+    dst_sort(file_out, file_dst)

--- a/src/python/deepgnn/graph_engine/snark/decoders.py
+++ b/src/python/deepgnn/graph_engine/snark/decoders.py
@@ -211,34 +211,48 @@ class LinearDecoder(Decoder):
     def __init__(self):
         """Initialize the Decoder."""
         super().__init__()
-        definition = r"(-1|\d+) (\d+) (\d+) ([-]?(?:[0-9]+(?:[.][0-9]*)?|[.][0-9]+))((?: (?:uint64|float)_feature\/[0-9]*\/(?:[-]?(?:[0-9]+(?:[.][0-9]*)?|[.][0-9]+),)*[-]?(?:[0-9]+(?:[.][0-9]*)?|[.][0-9]+))*)"
+        definition = r"(-1|[0-9]+) ([0-9]+) ([0-9]+) ([-]?(?:[0-9.]+))((?: (?:uint64|float)_feature\/[0-9]*\/(?:[-]?(?:[0-9.]+?),)*[-]?(?:[0-9.]+))*)"
         self.pattern = re.compile(definition)
 
     def decode(self, line: str):
         """Use json package to convert the json text line into node object."""
-        groups = self.pattern.match(line)
-        #print(groups.groups())
-        src, dst, typ, weight, features = groups.groups()
-        #print(line, groups, src, dst, type, weight, features)
-        #if src is None:
-        #    exit()
-        if line[0] == "-":  # is node
-            output = {
-                "node_id": int(dst),
-                "node_type": int(typ),
-                "node_weight": float(weight),
-            }
-            _load_features(output, features)
-        else:  # is edge
-            output = {
-                "src_id": int(src),
-                "dst_id": int(dst),
-                "edge_type": int(typ),
-                "weight": float(weight),
-            }
-            _load_features(output, features)
+        #from time import time
+        #time_start = time()
+        lines = " ".join(line)
+        #print((time() - time_start) * 10 ** 5)
+        #print(lines)
 
-        return output
+        #time_start = time()
+        groups = self.pattern.findall(lines)
+        #print((time() - time_start) * 10 ** 5)
+        #time_stp
+        #print(groups.groups())
+        #print(groups)
+        #print(groups.groups())
+        #src, dst, typ, weight, features = groups.groups()
+        #assert False
+
+        for src, dst, typ, weight, features in groups:
+            #print(line, groups, src, dst, type, weight, features)
+            #if src is None:
+            #    exit()
+            if line[0] == "-":  # is node
+                output = {
+                    "node_id": int(dst),
+                    "node_type": int(typ),
+                    "node_weight": float(weight),
+                }
+                _load_features(output, features)
+            else:  # is edge
+                output = {
+                    "src_id": int(src),
+                    "dst_id": int(dst),
+                    "edge_type": int(typ),
+                    "weight": float(weight),
+                }
+                _load_features(output, features)
+
+            yield output
 
 
 convert_map = {  # TODO all + sparse

--- a/src/python/deepgnn/graph_engine/snark/decoders.py
+++ b/src/python/deepgnn/graph_engine/snark/decoders.py
@@ -218,7 +218,8 @@ class LinearDecoder(Decoder):
         """Use json package to convert the json text line into node object."""
         src, dst, typ, weight, features = line.split(maxsplit=4)
 
-        if line[0] == "-":  # is node
+        src = int(src)
+        if src == -1:  # is node
             output = {
                 "node_id": int(dst),
                 "node_type": int(typ),
@@ -227,7 +228,7 @@ class LinearDecoder(Decoder):
             _load_features(output, features)
         else:  # is edge
             output = {
-                "src_id": int(src),
+                "src_id": src,
                 "dst_id": int(dst),
                 "edge_type": int(typ),
                 "weight": float(weight),
@@ -248,11 +249,9 @@ def _load_features(output, features):
         key, idx, value = values[i*3:i*3+3]
         if key not in output:
             output[key] = {}
-
-        if key == "binary_feature":
-            output[key][idx] = value.replace(",", "")
-        else:
-            output[key][idx] = list(map(convert_map[key], value.split(",")))
+        if key != "binary_feature":
+            value = list(map(convert_map[key], value.split(",")))
+        output[key][idx] = value
 
 
 def _dump_features(features: dict) -> str:
@@ -263,7 +262,11 @@ def _dump_features(features: dict) -> str:
             continue
 
         for idx, value in values.items():
-            output.append(f"{key}/{idx}/{','.join(map(str, value))}")
+            if key == "binary_feature":
+                v = str(value)
+            else:
+                v = ",".join(map(str, value))
+            output.append(f"{key}/{idx}/{v}")
     
     return "/".join(output)
 

--- a/src/python/deepgnn/graph_engine/snark/decoders.py
+++ b/src/python/deepgnn/graph_engine/snark/decoders.py
@@ -216,43 +216,25 @@ class LinearDecoder(Decoder):
 
     def decode(self, line: str):
         """Use json package to convert the json text line into node object."""
-        #from time import time
-        #time_start = time()
-        lines = " ".join(line)
-        #print((time() - time_start) * 10 ** 5)
-        #print(lines)
+        src, dst, typ, weight, *features = line.split()
 
-        #time_start = time()
-        groups = self.pattern.findall(lines)
-        #print((time() - time_start) * 10 ** 5)
-        #time_stp
-        #print(groups.groups())
-        #print(groups)
-        #print(groups.groups())
-        #src, dst, typ, weight, features = groups.groups()
-        #assert False
+        if line[0] == "-":  # is node
+            output = {
+                "node_id": int(dst),
+                "node_type": int(typ),
+                "node_weight": float(weight),
+            }
+            _load_features(output, features)
+        else:  # is edge
+            output = {
+                "src_id": int(src),
+                "dst_id": int(dst),
+                "edge_type": int(typ),
+                "weight": float(weight),
+            }
+            _load_features(output, features)
 
-        for src, dst, typ, weight, features in groups:
-            #print(line, groups, src, dst, type, weight, features)
-            #if src is None:
-            #    exit()
-            if line[0] == "-":  # is node
-                output = {
-                    "node_id": int(dst),
-                    "node_type": int(typ),
-                    "node_weight": float(weight),
-                }
-                _load_features(output, features)
-            else:  # is edge
-                output = {
-                    "src_id": int(src),
-                    "dst_id": int(dst),
-                    "edge_type": int(typ),
-                    "weight": float(weight),
-                }
-                _load_features(output, features)
-
-            yield output
+        return output
 
 
 convert_map = {  # TODO all + sparse
@@ -261,12 +243,10 @@ convert_map = {  # TODO all + sparse
 }
 
 def _load_features(output, features):
-    features = features.split()
     for feature in features:
         key, idx, value = feature.split("/")
         if key not in output:
             output[key] = {}
-        
 
         if key == "binary_feature":
             output[key][idx] = value.replace(",", "")

--- a/src/python/deepgnn/graph_engine/snark/decoders.py
+++ b/src/python/deepgnn/graph_engine/snark/decoders.py
@@ -214,9 +214,9 @@ class LinearDecoder(Decoder):
     def decode(self, line: str):
         """Use json package to convert the json text line into node object."""
         src, dst, type, weight, *features = line.split()
-        if int(dst) == -1:  # is node
+        if int(src) == -1:  # is node
             output = {
-                "node_id": int(src),
+                "node_id": int(dst),
                 "node_type": int(type),
                 "node_weight": float(weight),
             }
@@ -264,7 +264,7 @@ def json_to_linear(filename_in, filename_out):
         node = json.loads(line)
 
         file_out.write(
-            f'{node["node_id"]} -1 {node["node_type"]} {node["node_weight"]} {_dump_features(node)}\n'
+            f'-1 {node["node_id"]} {node["node_type"]} {node["node_weight"]} {_dump_features(node)}\n'
         )
 
         edge_list = sorted(
@@ -288,6 +288,9 @@ def src_sort(filename_in, filename_out):
     for line in file_in.readlines():
         src, dst, *_ = line.split()
         src, dst = int(src), int(dst)
+        if src == -1:
+            src = dst
+            dst = -1
         if src not in lines:
             lines[src] = []
         lines[src].append((src, dst, line))
@@ -309,9 +312,6 @@ def dst_sort(filename_in, filename_out):
     for line in file_in.readlines():
         src, dst, *_ = line.split()
         src, dst = int(src), int(dst)
-        if dst == -1:
-            dst = src
-            src = -1
         if dst not in lines:
             lines[dst] = []
         lines[dst].append((src, dst, line))

--- a/src/python/deepgnn/graph_engine/snark/decoders.py
+++ b/src/python/deepgnn/graph_engine/snark/decoders.py
@@ -216,7 +216,7 @@ class LinearDecoder(Decoder):
 
     def decode(self, line: str):
         """Use json package to convert the json text line into node object."""
-        src, dst, typ, weight, *features = line.split()
+        src, dst, typ, weight, features = line.split(maxsplit=4)
 
         if line[0] == "-":  # is node
             output = {
@@ -243,8 +243,9 @@ convert_map = {  # TODO all + sparse
 }
 
 def _load_features(output, features):
-    for feature in features:
-        key, idx, value = feature.split("/")
+    values = features.split("/")
+    for i in range(len(values) // 3):
+        key, idx, value = values[i*3:i*3+3]
         if key not in output:
             output[key] = {}
 
@@ -264,7 +265,7 @@ def _dump_features(features: dict) -> str:
         for idx, value in values.items():
             output.append(f"{key}/{idx}/{','.join(map(str, value))}")
     
-    return " ".join(output)
+    return "/".join(output)
 
 
 def json_to_linear(filename_in, filename_out):

--- a/src/python/deepgnn/graph_engine/snark/decoders.py
+++ b/src/python/deepgnn/graph_engine/snark/decoders.py
@@ -217,25 +217,7 @@ class LinearDecoder(Decoder):
     def decode(self, line: str):
         """Use json package to convert the json text line into node object."""
         src, dst, typ, weight, features = line.split(maxsplit=4)
-
-        src = int(src)
-        if src == -1:  # is node
-            output = {
-                "node_id": int(dst),
-                "node_type": int(typ),
-                "node_weight": float(weight),
-            }
-            _load_features(output, features)
-        else:  # is edge
-            output = {
-                "src_id": src,
-                "dst_id": int(dst),
-                "edge_type": int(typ),
-                "weight": float(weight),
-            }
-            _load_features(output, features)
-
-        return output
+        return src, dst, typ, weight, _load_features(features)
 
 
 convert_map = {  # TODO all + sparse
@@ -243,7 +225,9 @@ convert_map = {  # TODO all + sparse
     "uint64_feature": int,
 }
 
-def _load_features(output, features):
+
+def _load_features(features):
+    output = {}
     values = features.split("/")
     for i in range(len(values) // 3):
         key, idx, value = values[i*3:i*3+3]
@@ -252,6 +236,7 @@ def _load_features(output, features):
         if key != "binary_feature":
             value = list(map(convert_map[key], value.split(",")))
         output[key][idx] = value
+    return output
 
 
 def _dump_features(features: dict) -> str:

--- a/src/python/deepgnn/graph_engine/snark/dispatcher.py
+++ b/src/python/deepgnn/graph_engine/snark/dispatcher.py
@@ -99,7 +99,7 @@ class PipeDispatcher(Dispatcher):
             parallel_func = threading.Thread  # type: ignore
 
         self.parallel = parallel
-        self.count = 0
+        self.count = -1
         self.q_in = [mp.Pipe(False) for _ in range(parallel)]
         self.q_out: mp.Queue = mp.Queue(parallel)
         processes = [
@@ -132,11 +132,14 @@ class PipeDispatcher(Dispatcher):
         Args:
             line (str): graph element.
         """
-        self.q_in[self.count % self.parallel][1].send(line)
-        self.count += 1
+        i = line.find(" ")
+        if line[i+1:i+3] == "-1":  # if line is node
+            self.count += 1
 
-        if self.count % PROCESS_PRINT_INTERVAL == 0:
-            get_logger().info(f"record processed: {self.count}")
+            if self.count % PROCESS_PRINT_INTERVAL == 0:
+                get_logger().info(f"record processed: {self.count}")
+
+        self.q_in[self.count % self.parallel][1].send(line)
 
     def join(self):
         """Wait for all processes to finish work."""
@@ -216,7 +219,7 @@ class QueueDispatcher(Dispatcher):
         if use_threads:
             parallel_func = threading.Thread  # type: ignore
 
-        self.count = 0
+        self.count = -1
         self.num_partitions = num_partitions
         self.q_in: typing.List[mp.Queue] = [mp.Queue(2) for _ in range(num_partitions)]
         self.q_out: mp.Queue = mp.Queue(num_partitions)
@@ -255,13 +258,15 @@ class QueueDispatcher(Dispatcher):
         Args:
             line (str): String representation of a graph element.
         """
+        i = line.find(" ")
+        if line[i+1:i+3] == "-1":  # if line is node
+            self.count += 1
+            if self.count % PROCESS_PRINT_INTERVAL == 0:
+                get_logger().info(f"record processed: {self.count}")
+
         partition = self.partition_func(line)
         self.q_in[partition].put(line)
         self.active_partitions.add(partition)
-
-        self.count += 1
-        if self.count % PROCESS_PRINT_INTERVAL == 0:
-            get_logger().info(f"record processed: {self.count}")
 
     def join(self):
         """Wrapup conversion."""

--- a/src/python/deepgnn/graph_engine/snark/tests/BUILD
+++ b/src/python/deepgnn/graph_engine/snark/tests/BUILD
@@ -249,3 +249,25 @@ py_test(
     ],
     target_compatible_with = ["@bazel_tools//platforms:linux"],
 )
+
+py_binary(
+    name = "convert_benchmark",
+    srcs = ["convert_benchmark.py"],
+    imports = ["../../../../"],
+    main = "convert_benchmark.py",
+    python_version = "PY3",
+    srcs_version = "PY3",
+    deps = [
+        "//src/python/deepgnn/graph_engine/snark:graph_engine_snark",
+        "//src/python/deepgnn/graph_engine:graph_engine",
+        requirement("importlib_metadata"),
+        requirement("numpy"),
+        requirement("pytest"),
+        requirement("fsspec"),
+        requirement("networkx"),
+        requirement("opencensus"),
+        requirement("opencensus-context"),
+        requirement("opencensus-ext-azure"),
+        requirement("azure-datalake-store"),
+    ],
+)

--- a/src/python/deepgnn/graph_engine/snark/tests/convert_benchmark.py
+++ b/src/python/deepgnn/graph_engine/snark/tests/convert_benchmark.py
@@ -101,7 +101,7 @@ if __name__ == "__main__":
 
     linear_name = os.path.join(input_dir.name, "graph.linear")
 
-    data_name, meta_name = generate_json(input_dir.name, 10 ** 4, 20)  # TODO 1B
+    data_name, meta_name = generate_json(input_dir.name, 10 ** 5, 20)  # TODO 1B
     print(f"JSON to Linear: {benchmark_json_to_linear(data_name, meta_name, linear_name)}")
     print(f"JSON to Binary: {benchmark_json_to_binary(data_name, meta_name, json_binary_dir.name)}")
     print(f"Linear to Binary: {benchmark_linear_to_binary(linear_name, meta_name, linear_binary_dir.name)}")

--- a/src/python/deepgnn/graph_engine/snark/tests/convert_benchmark.py
+++ b/src/python/deepgnn/graph_engine/snark/tests/convert_benchmark.py
@@ -36,14 +36,20 @@ def generate_json(folder, N, fan_out):
             }
             for ii in range(fan_out)
         ]
-        
+
         node = {
             "node_id": i,
             "node_type": int(i > (N // 2)),
             "node_weight": 1,
-            "neighbor": {"0": {str((dst_id + ii) % N): 0.5 for ii in range(fan_out)}, "1": {}},
+            "neighbor": {
+                "0": {str((dst_id + ii) % N): 0.5 for ii in range(fan_out)},
+                "1": {},
+            },
             "uint64_feature": {},
-            "float_feature": {"0": [0, 1, 2, 3, 4, 5], "1": [-0.01, -0.02, .3, .4, .5]},
+            "float_feature": {
+                "0": [0, 1, 2, 3, 4, 5],
+                "1": [-0.01, -0.02, 0.3, 0.4, 0.5],
+            },
             "binary_feature": {},
             "edge": edges,
         }
@@ -74,7 +80,8 @@ def benchmark_json_to_linear(data_name, meta_name, linear_name):
 
 def benchmark_to_binary(data_name, meta_name, output_dir, decoder_type):
     from deepgnn.graph_engine.snark import dispatcher
-    dispatcher.PROCESS_PRINT_INTERVAL = 10 ** 10
+
+    dispatcher.PROCESS_PRINT_INTERVAL = 10**10
     time_start = time()
     convert.MultiWorkersConverter(
         graph_path=data_name,
@@ -101,7 +108,19 @@ if __name__ == "__main__":
 
     linear_name = os.path.join(input_dir.name, "graph.linear")
 
-    data_name, meta_name = generate_json(input_dir.name, 10 ** 5, 20)  # TODO 1B
-    print(f"JSON to Linear: {benchmark_json_to_linear(data_name, meta_name, linear_name)}")
-    print(f"JSON to Binary: {benchmark_json_to_binary(data_name, meta_name, json_binary_dir.name)}")
-    print(f"Linear to Binary: {benchmark_linear_to_binary(linear_name, meta_name, linear_binary_dir.name)}")
+    data_name, meta_name = generate_json(input_dir.name, 10**5, 20)  # TODO 1B
+    print(
+        f"JSON to Linear: {benchmark_json_to_linear(data_name, meta_name, linear_name)}"
+    )
+    # print(f"JSON to Binary: {benchmark_json_to_binary(data_name, meta_name, json_binary_dir.name)}")
+
+    import cProfile, pstats
+    from pstats import SortKey
+
+    pr = cProfile.Profile()
+    pr.enable()
+    print(
+        f"Linear to Binary: {benchmark_linear_to_binary(linear_name, meta_name, linear_binary_dir.name)}"
+    )
+    pr.disable()
+    ps = pstats.Stats(pr).sort_stats(SortKey.CUMULATIVE).print_stats()

--- a/src/python/deepgnn/graph_engine/snark/tests/convert_benchmark.py
+++ b/src/python/deepgnn/graph_engine/snark/tests/convert_benchmark.py
@@ -102,25 +102,42 @@ def benchmark_linear_to_binary(data_name, meta_name, output_dir):
 
 
 if __name__ == "__main__":
-    input_dir = tempfile.TemporaryDirectory()
-    json_binary_dir = tempfile.TemporaryDirectory()
-    linear_binary_dir = tempfile.TemporaryDirectory()
+    input_dir = "/tmp/convert_benchmark"
+    json_binary_dir = "/tmp/json_binary_dir"
+    linear_binary_dir = "/tmp/linear_binary_dir"
 
-    linear_name = os.path.join(input_dir.name, "graph.linear")
+    linear_name = os.path.join(input_dir, "graph.linear")
 
-    data_name, meta_name = generate_json(input_dir.name, 10**5, 20)  # TODO 1B
+    data_name, meta_name = generate_json(input_dir, 10**5, 20)#5 * 10**4, 20)
     print(
         f"JSON to Linear: {benchmark_json_to_linear(data_name, meta_name, linear_name)}"
     )
-    print(f"JSON to Binary: {benchmark_json_to_binary(data_name, meta_name, json_binary_dir.name)}")
 
-    #import cProfile, pstats
-    #from pstats import SortKey
+    import cProfile, pstats
+    from pstats import SortKey
 
-    #pr = cProfile.Profile()
-    #pr.enable()
-    print(
-        f"Linear to Binary: {benchmark_linear_to_binary(linear_name, meta_name, linear_binary_dir.name)}"
-    )
-    #pr.disable()
-    #ps = pstats.Stats(pr).sort_stats(SortKey.CUMULATIVE).print_stats()
+    profile = False
+    if profile:
+        pr = cProfile.Profile()
+        pr.enable()
+
+    print(f"JSON to Binary: {benchmark_json_to_binary(data_name, meta_name, json_binary_dir)}")
+
+    if profile:
+        pr.disable()
+        ps = pstats.Stats(pr)
+        ps.strip_dirs()
+        ps.sort_stats(SortKey.CUMULATIVE) #.print_stats()
+        ps.dump_stats("/home/user/DeepGNN/profile_json")
+
+        pr = cProfile.Profile()
+        pr.enable()
+
+    print(f"Linear to Binary: {benchmark_linear_to_binary(linear_name, meta_name, linear_binary_dir)}")
+
+    if profile:
+        pr.disable()
+        ps = pstats.Stats(pr)
+        ps.strip_dirs()
+        ps.sort_stats(SortKey.CUMULATIVE) #.print_stats()
+        ps.dump_stats("/home/user/DeepGNN/profile")

--- a/src/python/deepgnn/graph_engine/snark/tests/convert_benchmark.py
+++ b/src/python/deepgnn/graph_engine/snark/tests/convert_benchmark.py
@@ -100,8 +100,11 @@ def benchmark_json_to_binary(data_name, meta_name, output_dir):
 
 def benchmark_linear_to_binary(data_name, meta_name, output_dir):
     # buffer_size reduces number of TextFileIterator q.get calls == json, record_per_step reduces number TextFileIterator.__next__ == json
-    return benchmark_to_binary(data_name, meta_name, output_dir, DecoderType.LINEAR, buffer_size=50 // 4, record_per_step=512 * 21)
+    return benchmark_to_binary(data_name, meta_name, output_dir, DecoderType.LINEAR, buffer_size=50 // 4, record_per_step=512 * (EDGES + 1))
 
+
+NODES = 10**5
+EDGES = 20
 
 if __name__ == "__main__":
     input_dir = "/tmp/convert_benchmark"
@@ -110,7 +113,7 @@ if __name__ == "__main__":
 
     linear_name = os.path.join(input_dir, "graph.linear")
 
-    data_name, meta_name = generate_json(input_dir, 10**5, 20)#5 * 10**4, 20)
+    data_name, meta_name = generate_json(input_dir, NODES, EDGES)
     print(
         f"JSON to Linear: {benchmark_json_to_linear(data_name, meta_name, linear_name)}"
     )
@@ -118,20 +121,23 @@ if __name__ == "__main__":
     import cProfile, pstats
     from pstats import SortKey
 
-    profile = True
+    profile = False
+
+    if True:
+        if profile:
+            pr = cProfile.Profile()
+            pr.enable()
+
+        print(f"JSON to Binary: {benchmark_json_to_binary(data_name, meta_name, json_binary_dir)}")
+
+        if profile:
+            pr.disable()
+            ps = pstats.Stats(pr)
+            ps.strip_dirs()
+            ps.sort_stats(SortKey.CUMULATIVE) #.print_stats()
+            ps.dump_stats("/home/user/DeepGNN/profile_json")
+
     if profile:
-        pr = cProfile.Profile()
-        pr.enable()
-
-    print(f"JSON to Binary: {benchmark_json_to_binary(data_name, meta_name, json_binary_dir)}")
-
-    if profile:
-        pr.disable()
-        ps = pstats.Stats(pr)
-        ps.strip_dirs()
-        ps.sort_stats(SortKey.CUMULATIVE) #.print_stats()
-        ps.dump_stats("/home/user/DeepGNN/profile_json")
-
         pr = cProfile.Profile()
         pr.enable()
 

--- a/src/python/deepgnn/graph_engine/snark/tests/convert_benchmark.py
+++ b/src/python/deepgnn/graph_engine/snark/tests/convert_benchmark.py
@@ -112,15 +112,15 @@ if __name__ == "__main__":
     print(
         f"JSON to Linear: {benchmark_json_to_linear(data_name, meta_name, linear_name)}"
     )
-    # print(f"JSON to Binary: {benchmark_json_to_binary(data_name, meta_name, json_binary_dir.name)}")
+    print(f"JSON to Binary: {benchmark_json_to_binary(data_name, meta_name, json_binary_dir.name)}")
 
-    import cProfile, pstats
-    from pstats import SortKey
+    #import cProfile, pstats
+    #from pstats import SortKey
 
-    pr = cProfile.Profile()
-    pr.enable()
+    #pr = cProfile.Profile()
+    #pr.enable()
     print(
         f"Linear to Binary: {benchmark_linear_to_binary(linear_name, meta_name, linear_binary_dir.name)}"
     )
-    pr.disable()
-    ps = pstats.Stats(pr).sort_stats(SortKey.CUMULATIVE).print_stats()
+    #pr.disable()
+    #ps = pstats.Stats(pr).sort_stats(SortKey.CUMULATIVE).print_stats()

--- a/src/python/deepgnn/graph_engine/snark/tests/convert_benchmark.py
+++ b/src/python/deepgnn/graph_engine/snark/tests/convert_benchmark.py
@@ -78,7 +78,7 @@ def benchmark_json_to_linear(data_name, meta_name, linear_name):
     return time() - time_start
 
 
-def benchmark_to_binary(data_name, meta_name, output_dir, decoder_type):
+def benchmark_to_binary(data_name, meta_name, output_dir, decoder_type, **kw):
     from deepgnn.graph_engine.snark import dispatcher
 
     dispatcher.PROCESS_PRINT_INTERVAL = 10**10
@@ -89,6 +89,7 @@ def benchmark_to_binary(data_name, meta_name, output_dir, decoder_type):
         partition_count=1,
         output_dir=output_dir,
         decoder_type=decoder_type,
+        **kw,
     ).convert()
     return time() - time_start
 
@@ -98,7 +99,8 @@ def benchmark_json_to_binary(data_name, meta_name, output_dir):
 
 
 def benchmark_linear_to_binary(data_name, meta_name, output_dir):
-    return benchmark_to_binary(data_name, meta_name, output_dir, DecoderType.LINEAR)
+    # buffer_size reduces number of TextFileIterator q.get calls == json, record_per_step reduces number TextFileIterator.__next__ == json
+    return benchmark_to_binary(data_name, meta_name, output_dir, DecoderType.LINEAR, buffer_size=50 // 4, record_per_step=512 * 21)
 
 
 if __name__ == "__main__":
@@ -116,7 +118,7 @@ if __name__ == "__main__":
     import cProfile, pstats
     from pstats import SortKey
 
-    profile = False
+    profile = True
     if profile:
         pr = cProfile.Profile()
         pr.enable()

--- a/src/python/deepgnn/graph_engine/snark/tests/convert_benchmark.py
+++ b/src/python/deepgnn/graph_engine/snark/tests/convert_benchmark.py
@@ -1,0 +1,107 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+import json
+import os
+from time import time
+import struct
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+import numpy as np
+import numpy.testing as npt
+
+import deepgnn.graph_engine.snark.convert as convert
+from deepgnn.graph_engine.snark.decoders import DecoderType, json_to_linear, dst_sort
+from deepgnn.graph_engine.snark.dispatcher import QueueDispatcher
+
+
+def generate_json(folder, N, fan_out):
+    data = open(os.path.join(folder, "graph.json"), "w+")
+    dst_ids = np.random.randint(0, N, N)
+    for i in range(N):
+        dst_id = int(dst_ids[i])
+
+        edges = [
+            {
+                "src_id": i,
+                "dst_id": (dst_id + ii) % N,
+                "edge_type": 0,
+                "weight": 0.5,
+                "uint64_feature": {"0": [1, 2, 3, 4, 5]},
+                "float_feature": {},
+                "binary_feature": {},
+            }
+            for ii in range(fan_out)
+        ]
+        
+        node = {
+            "node_id": i,
+            "node_type": int(i > (N // 2)),
+            "node_weight": 1,
+            "neighbor": {"0": {str((dst_id + ii) % N): 0.5 for ii in range(fan_out)}, "1": {}},
+            "uint64_feature": {},
+            "float_feature": {"0": [0, 1, 2, 3, 4, 5], "1": [-0.01, -0.02, .3, .4, .5]},
+            "binary_feature": {},
+            "edge": edges,
+        }
+        json.dump(node, data)
+        data.write("\n")
+    data.flush()
+
+    meta = open(os.path.join(folder, "meta.txt"), "w+")
+    meta.write(
+        '{"node_type_num": 3, "edge_type_num": 2, \
+        "node_uint64_feature_num": 0, "node_float_feature_num": 2, \
+        "node_binary_feature_num": 0, "edge_uint64_feature_num": 1, \
+        "edge_float_feature_num": 1, "edge_binary_feature_num": 1}'
+    )
+    meta.flush()
+
+    data.close()
+    meta.close()
+
+    return data.name, meta.name
+
+
+def benchmark_json_to_linear(data_name, meta_name, linear_name):
+    time_start = time()
+    json_to_linear(data_name, linear_name)
+    return time() - time_start
+
+
+def benchmark_to_binary(data_name, meta_name, output_dir, decoder_type):
+    from deepgnn.graph_engine.snark import dispatcher
+    dispatcher.PROCESS_PRINT_INTERVAL = 10 ** 10
+    time_start = time()
+    convert.MultiWorkersConverter(
+        graph_path=data_name,
+        meta_path=meta_name,
+        partition_count=1,
+        output_dir=output_dir,
+        decoder_type=decoder_type,
+    ).convert()
+    return time() - time_start
+
+
+def benchmark_json_to_binary(data_name, meta_name, output_dir):
+    return benchmark_to_binary(data_name, meta_name, output_dir, DecoderType.JSON)
+
+
+def benchmark_linear_to_binary(data_name, meta_name, output_dir):
+    return benchmark_to_binary(data_name, meta_name, output_dir, DecoderType.LINEAR)
+
+
+if __name__ == "__main__":
+    input_dir = tempfile.TemporaryDirectory()
+    json_binary_dir = tempfile.TemporaryDirectory()
+    linear_binary_dir = tempfile.TemporaryDirectory()
+
+    linear_name = os.path.join(input_dir.name, "graph.linear")
+
+    data_name, meta_name = generate_json(input_dir.name, 10 ** 4, 20)  # TODO 1B
+    print(f"JSON to Linear: {benchmark_json_to_linear(data_name, meta_name, linear_name)}")
+    print(f"JSON to Binary: {benchmark_json_to_binary(data_name, meta_name, json_binary_dir.name)}")
+    print(f"Linear to Binary: {benchmark_linear_to_binary(linear_name, meta_name, linear_binary_dir.name)}")

--- a/src/python/deepgnn/graph_engine/snark/tests/convert_test.py
+++ b/src/python/deepgnn/graph_engine/snark/tests/convert_test.py
@@ -370,8 +370,10 @@ def test_edge_alias_tables(triangle_graph):
         def __init__(self):
             self.count = -1
 
-        def __call__(self, x):
-            self.count += 1
+        def __call__(self, line):
+            i = line.find(" ")
+            if line[i+1:i+3] == "-1":  # if line is node
+                self.count += 1
             return self.count % 2
 
     d = QueueDispatcher(
@@ -426,8 +428,10 @@ def test_node_alias_tables(triangle_graph):
         def __init__(self):
             self.count = -1
 
-        def __call__(self, x):
-            self.count += 1
+        def __call__(self, line):
+            i = line.find(" ")
+            if line[i+1:i+3] == "-1":  # if line is node
+                self.count += 1
             return self.count % 2
 
     d = QueueDispatcher(
@@ -919,15 +923,16 @@ def test_sanity_node_map_reversed(triangle_graph_reversed):
         expected_size = 3 * (2 * 8 + 4)
         result = nm.read(expected_size + 8)
         assert len(result) == expected_size
-        assert result[0:8] == (9).to_bytes(8, byteorder=sys.byteorder)
+
+        assert result[0:8] == (0).to_bytes(8, byteorder=sys.byteorder)
         assert result[8:16] == (0).to_bytes(8, byteorder=sys.byteorder)
-        assert result[16:20] == (0).to_bytes(4, byteorder=sys.byteorder)
-        assert result[20:28] == (0).to_bytes(8, byteorder=sys.byteorder)
+        assert result[16:20] == (1).to_bytes(4, byteorder=sys.byteorder)
+        assert result[20:28] == (5).to_bytes(8, byteorder=sys.byteorder)
         assert result[28:36] == (1).to_bytes(8, byteorder=sys.byteorder)
-        assert result[36:40] == (1).to_bytes(4, byteorder=sys.byteorder)
-        assert result[40:48] == (5).to_bytes(8, byteorder=sys.byteorder)
+        assert result[36:40] == (2).to_bytes(4, byteorder=sys.byteorder)
+        assert result[40:48] == (9).to_bytes(8, byteorder=sys.byteorder)
         assert result[48:56] == (2).to_bytes(8, byteorder=sys.byteorder)
-        assert result[56:60] == (2).to_bytes(4, byteorder=sys.byteorder)
+        assert result[56:60] == (0).to_bytes(4, byteorder=sys.byteorder)
 
 
 @pytest.mark.parametrize("triangle_graph_reversed", param, indirect=True)
@@ -969,8 +974,8 @@ def test_sanity_node_feature_index_reversed(triangle_graph_reversed):
         result = ni.read(expected_size + 1)
         assert len(result) == expected_size
         assert result[0:8] == (0).to_bytes(8, byteorder=sys.byteorder)
-        assert result[8:16] == (8).to_bytes(8, byteorder=sys.byteorder)
-        assert result[16:24] == (16).to_bytes(8, byteorder=sys.byteorder)
+        assert result[8:16] == (4).to_bytes(8, byteorder=sys.byteorder)  # 8
+        assert result[16:24] == (12).to_bytes(8, byteorder=sys.byteorder)  # 12 -- difference because sorted now
         assert result[24:32] == (20).to_bytes(8, byteorder=sys.byteorder)
         assert result[32:40] == (28).to_bytes(8, byteorder=sys.byteorder)
         assert result[40:48] == (36).to_bytes(8, byteorder=sys.byteorder)
@@ -1130,8 +1135,10 @@ def test_edge_alias_tables_reversed(triangle_graph_reversed):
         def __init__(self):
             self.count = -1
 
-        def __call__(self, x):
-            self.count += 1
+        def __call__(self, line):
+            i = line.find(" ")
+            if line[i+1:i+3] == "-1":  # if line is node
+                self.count += 1
             return self.count % 2
 
     d = QueueDispatcher(
@@ -1186,8 +1193,10 @@ def test_node_alias_tables_reversed(triangle_graph_reversed):
         def __init__(self):
             self.count = -1
 
-        def __call__(self, x):
-            self.count += 1
+        def __call__(self, line):
+            i = line.find(" ")
+            if line[i+1:i+3] == "-1":  # if line is node
+                self.count += 1
             return self.count % 2
 
     d = QueueDispatcher(
@@ -1216,7 +1225,7 @@ def test_node_alias_tables_reversed(triangle_graph_reversed):
                 result = ea.read(20 + 1)
                 print(v, len(result))
 
-    with open("{}/node_1_1.alias".format(output.name), "rb") as ea:
+    with open("{}/node_1_0.alias".format(output.name), "rb") as ea:
         expected_size = 20  # Only 1 record
         result = ea.read(expected_size + 1)
         assert len(result) == expected_size
@@ -1224,7 +1233,7 @@ def test_node_alias_tables_reversed(triangle_graph_reversed):
         assert result[8:16] == (0).to_bytes(8, byteorder=sys.byteorder)
         assert result[16:20] == struct.pack("=f", 1.0)
 
-    with open("{}/node_2_0.alias".format(output.name), "rb") as ea:
+    with open("{}/node_2_1.alias".format(output.name), "rb") as ea:
         expected_size = 20  # Only 1 record
         result = ea.read(expected_size + 1)
         assert len(result) == expected_size
@@ -1233,8 +1242,8 @@ def test_node_alias_tables_reversed(triangle_graph_reversed):
         assert result[16:20] == struct.pack("=f", 1.0)
 
     assert os.path.getsize("{}/node_0_1.alias".format(output.name)) == 0
-    assert os.path.getsize("{}/node_2_1.alias".format(output.name)) == 0
-    assert os.path.getsize("{}/node_1_0.alias".format(output.name)) == 0
+    assert os.path.getsize("{}/node_1_1.alias".format(output.name)) == 0
+    assert os.path.getsize("{}/node_2_0.alias".format(output.name)) == 0
 
 
 if __name__ == "__main__":

--- a/src/python/deepgnn/graph_engine/snark/tests/convert_test.py
+++ b/src/python/deepgnn/graph_engine/snark/tests/convert_test.py
@@ -13,7 +13,7 @@ import numpy as np
 import numpy.testing as npt
 
 import deepgnn.graph_engine.snark.convert as convert
-from deepgnn.graph_engine.snark.decoders import DecoderType
+from deepgnn.graph_engine.snark.decoders import DecoderType, json_to_linear
 from deepgnn.graph_engine.snark.dispatcher import QueueDispatcher
 
 
@@ -97,7 +97,12 @@ def triangle_graph_json(folder):
 
     data.close()
     meta.close()
-    return data.name, meta.name
+
+
+    output_name = os.path.join(folder, "graph.linear")
+    json_to_linear(data.name, output_name)
+
+    return output_name, meta.name
 
 
 def triangle_graph_tsv(folder):
@@ -125,7 +130,7 @@ def triangle_graph_tsv(folder):
 @pytest.fixture(scope="module")
 def triangle_graph(request):
     workdir = tempfile.TemporaryDirectory()
-    if request.param == DecoderType.JSON:
+    if request.param == DecoderType.JSON or request.param == DecoderType.LINEAR:
         data_name, meta_name = triangle_graph_json(workdir.name)
     elif request.param == DecoderType.TSV:
         data_name, meta_name = triangle_graph_tsv(workdir.name)
@@ -136,7 +141,7 @@ def triangle_graph(request):
     workdir.cleanup()
 
 
-param = [DecoderType.JSON, DecoderType.TSV]
+param = [DecoderType.LINEAR]  #, DecoderType.TSV]
 
 
 @pytest.mark.parametrize("triangle_graph", param, indirect=True)
@@ -165,7 +170,7 @@ def test_sanity_node_map(triangle_graph):
         assert result[48:56] == (2).to_bytes(8, byteorder=sys.byteorder)
         assert result[56:60] == (2).to_bytes(4, byteorder=sys.byteorder)
 
-
+'''
 @pytest.mark.parametrize("triangle_graph", param, indirect=True)
 def test_sanity_node_index(triangle_graph):
     output = tempfile.TemporaryDirectory()
@@ -579,8 +584,8 @@ def graph_with_sparse_features_json(folder):
     data.close()
     meta.close()
     return data.name, meta.name
-
-
+'''
+"""
 @pytest.fixture(scope="module")
 def graph_with_sparse_features(request):
     workdir = tempfile.TemporaryDirectory()
@@ -784,7 +789,7 @@ def test_sanity_edge_sparse_features_data(graph_with_sparse_features):
         npt.assert_allclose(
             np.frombuffer(result[386:expected_size], dtype=np.float32), [5.5, 6.7]
         )
-
+"""
 
 if __name__ == "__main__":
     sys.exit(

--- a/src/python/deepgnn/graph_engine/snark/tests/convert_test.py
+++ b/src/python/deepgnn/graph_engine/snark/tests/convert_test.py
@@ -371,9 +371,7 @@ def test_edge_alias_tables(triangle_graph):
             self.count = -1
 
         def __call__(self, line):
-            i = line.find(" ")
-            if line[i+1:i+3] == "-1":  # if line is node
-                self.count += 1
+            self.count += 1
             return self.count % 2
 
     d = QueueDispatcher(
@@ -429,9 +427,7 @@ def test_node_alias_tables(triangle_graph):
             self.count = -1
 
         def __call__(self, line):
-            i = line.find(" ")
-            if line[i+1:i+3] == "-1":  # if line is node
-                self.count += 1
+            self.count += 1
             return self.count % 2
 
     d = QueueDispatcher(
@@ -1136,9 +1132,7 @@ def test_edge_alias_tables_reversed(triangle_graph_reversed):
             self.count = -1
 
         def __call__(self, line):
-            i = line.find(" ")
-            if line[i+1:i+3] == "-1":  # if line is node
-                self.count += 1
+            self.count += 1
             return self.count % 2
 
     d = QueueDispatcher(
@@ -1194,9 +1188,7 @@ def test_node_alias_tables_reversed(triangle_graph_reversed):
             self.count = -1
 
         def __call__(self, line):
-            i = line.find(" ")
-            if line[i+1:i+3] == "-1":  # if line is node
-                self.count += 1
+            self.count += 1
             return self.count % 2
 
     d = QueueDispatcher(

--- a/src/python/deepgnn/graph_engine/snark/tests/convert_test.py
+++ b/src/python/deepgnn/graph_engine/snark/tests/convert_test.py
@@ -98,7 +98,6 @@ def triangle_graph_json(folder):
     data.close()
     meta.close()
 
-
     output_name = os.path.join(folder, "graph.linear")
     json_to_linear(data.name, output_name)
 
@@ -170,7 +169,7 @@ def test_sanity_node_map(triangle_graph):
         assert result[48:56] == (2).to_bytes(8, byteorder=sys.byteorder)
         assert result[56:60] == (2).to_bytes(4, byteorder=sys.byteorder)
 
-'''
+
 @pytest.mark.parametrize("triangle_graph", param, indirect=True)
 def test_sanity_node_index(triangle_graph):
     output = tempfile.TemporaryDirectory()
@@ -451,6 +450,16 @@ def test_node_alias_tables(triangle_graph):
         assert result[8:16] == (0).to_bytes(8, byteorder=sys.byteorder)
         assert result[16:20] == struct.pack("=f", 1.0)
 
+    for v in os.listdir(output.name):
+        if 'alias' in v and 'node' in v:
+            with open("{}/{}".format(output.name, v), "rb") as ea:
+                result = ea.read(20 + 1)
+                print(v, len(result))
+
+
+
+    assert False, [v for v in  [1]]
+
     with open("{}/node_1_1.alias".format(output.name), "rb") as ea:
         expected_size = 20  # Only 1 record
         result = ea.read(expected_size + 1)
@@ -583,13 +592,16 @@ def graph_with_sparse_features_json(folder):
 
     data.close()
     meta.close()
-    return data.name, meta.name
-'''
-"""
+
+    output_name = os.path.join(folder, "graph.linear")
+    json_to_linear(data.name, output_name)
+
+    return output_name, meta.name
+
 @pytest.fixture(scope="module")
 def graph_with_sparse_features(request):
     workdir = tempfile.TemporaryDirectory()
-    if request.param == DecoderType.JSON:
+    if request.param == DecoderType.JSON or request.param == DecoderType.LINEAR:
         data_name, meta_name = graph_with_sparse_features_json(workdir.name)
     else:
         raise ValueError("Unsupported format.")
@@ -599,7 +611,7 @@ def graph_with_sparse_features(request):
 
 
 @pytest.mark.parametrize(
-    "graph_with_sparse_features", [DecoderType.JSON], indirect=True
+    "graph_with_sparse_features", [DecoderType.LINEAR], indirect=True
 )
 def test_sanity_node_sparse_features_index(graph_with_sparse_features):
     output = tempfile.TemporaryDirectory()
@@ -623,7 +635,7 @@ def test_sanity_node_sparse_features_index(graph_with_sparse_features):
 
 
 @pytest.mark.parametrize(
-    "graph_with_sparse_features", [DecoderType.JSON], indirect=True
+    "graph_with_sparse_features", [DecoderType.LINEAR], indirect=True
 )
 def test_sanity_node_sparse_features_data(graph_with_sparse_features):
     output = tempfile.TemporaryDirectory()
@@ -670,7 +682,7 @@ def test_sanity_node_sparse_features_data(graph_with_sparse_features):
 
 
 @pytest.mark.parametrize(
-    "graph_with_sparse_features", [DecoderType.JSON], indirect=True
+    "graph_with_sparse_features", [DecoderType.LINEAR], indirect=True
 )
 def test_sanity_edge_sparse_features_index(graph_with_sparse_features):
     output = tempfile.TemporaryDirectory()
@@ -695,7 +707,7 @@ def test_sanity_edge_sparse_features_index(graph_with_sparse_features):
 
 
 @pytest.mark.parametrize(
-    "graph_with_sparse_features", [DecoderType.JSON], indirect=True
+    "graph_with_sparse_features", [DecoderType.LINEAR], indirect=True
 )
 def test_sanity_edge_sparse_features_data(graph_with_sparse_features):
     output = tempfile.TemporaryDirectory()
@@ -789,7 +801,7 @@ def test_sanity_edge_sparse_features_data(graph_with_sparse_features):
         npt.assert_allclose(
             np.frombuffer(result[386:expected_size], dtype=np.float32), [5.5, 6.7]
         )
-"""
+
 
 if __name__ == "__main__":
     sys.exit(

--- a/src/python/deepgnn/graph_engine/snark/tests/convert_test.py
+++ b/src/python/deepgnn/graph_engine/snark/tests/convert_test.py
@@ -140,7 +140,7 @@ def triangle_graph(request):
     workdir.cleanup()
 
 
-param = [DecoderType.LINEAR]  #, DecoderType.TSV]
+param = [DecoderType.LINEAR]  # , DecoderType.TSV]
 
 
 @pytest.mark.parametrize("triangle_graph", param, indirect=True)
@@ -451,7 +451,7 @@ def test_node_alias_tables(triangle_graph):
         assert result[16:20] == struct.pack("=f", 1.0)
 
     for v in os.listdir(output.name):
-        if 'alias' in v and 'node' in v:
+        if "alias" in v and "node" in v:
             with open("{}/{}".format(output.name, v), "rb") as ea:
                 result = ea.read(20 + 1)
                 print(v, len(result))
@@ -593,6 +593,7 @@ def graph_with_sparse_features_json(folder):
     json_to_linear(data.name, output_name)
 
     return output_name, meta.name
+
 
 @pytest.fixture(scope="module")
 def graph_with_sparse_features(request):
@@ -900,7 +901,7 @@ def triangle_graph_reversed(request):
     workdir.cleanup()
 
 
-param = [DecoderType.LINEAR]  #, DecoderType.TSV]
+param = [DecoderType.LINEAR]  # , DecoderType.TSV]
 
 
 @pytest.mark.parametrize("triangle_graph_reversed", param, indirect=True)
@@ -971,7 +972,9 @@ def test_sanity_node_feature_index_reversed(triangle_graph_reversed):
         assert len(result) == expected_size
         assert result[0:8] == (0).to_bytes(8, byteorder=sys.byteorder)
         assert result[8:16] == (4).to_bytes(8, byteorder=sys.byteorder)  # 8
-        assert result[16:24] == (12).to_bytes(8, byteorder=sys.byteorder)  # 12 -- difference because sorted now
+        assert result[16:24] == (12).to_bytes(
+            8, byteorder=sys.byteorder
+        )  # 12 -- difference because sorted now
         assert result[24:32] == (20).to_bytes(8, byteorder=sys.byteorder)
         assert result[32:40] == (28).to_bytes(8, byteorder=sys.byteorder)
         assert result[40:48] == (36).to_bytes(8, byteorder=sys.byteorder)
@@ -1212,7 +1215,7 @@ def test_node_alias_tables_reversed(triangle_graph_reversed):
         assert result[16:20] == struct.pack("=f", 1.0)
 
     for v in os.listdir(output.name):
-        if 'alias' in v and 'node' in v:
+        if "alias" in v and "node" in v:
             with open("{}/{}".format(output.name, v), "rb") as ea:
                 result = ea.read(20 + 1)
                 print(v, len(result))


### PR DESCRIPTION
Externalize graph format
- Make easier to convert from parquet/orvo to our input format.
- Support neighbor inversion // sorting by dst nodes.
- JSON can't handle high number of edges well.