### PR TITLE
Simplify decoder interface and optimize binary writers.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,4 +6,4 @@
 
 * Replace converter and dispatcher's argument "decoder_type" -> "decoder" that accepts Decoder object directly instead of DecoderType enum. Replace DecoderType enum with type hint.
 
-* Make Decoder.decode a generator that yields a node then its outgoing edges in order. Yield format is -1/src node_id/dst type weight features, with features being a list of dense features as ndarrays and sparse features as 2 tuples, coordinates and values.
+* Make Decoder.decode a generator that yields a node then its outgoing edges in order. The yield format for nodes/edges is (-1/src, node_id/dst, type, weight, features), with features being a list of dense features as ndarrays and sparse features as 2 tuples, coordinates and values.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,5 @@
 * Dispatchers make argument 'process' default to converter.process.convert_process and set the argument after decoder type.
 
 * Replace converter and dispatcher's argument "decoder_type" -> "decoder" that accepts Decoder object directly instead of DecoderType enum. Replace DecoderType enum with type hint.
+
+* Make Decoder.decode a generator that yields a node then its outgoing edges in order. Yield format is -1/src node_id/dst type weight features, with features being a list of dense features as ndarrays and sparse features as 2 tuples, coordinates and values.

--- a/src/python/deepgnn/graph_engine/snark/converter/process.py
+++ b/src/python/deepgnn/graph_engine/snark/converter/process.py
@@ -57,9 +57,9 @@ def converter_process(
 
     node_count = 0
     edge_count = 0
-    node_weight = [0] * node_type_num
+    node_weight = [0.0] * node_type_num
     node_type_count = [0] * node_type_num
-    edge_weight = [0] * edge_type_num
+    edge_weight = [0.0] * edge_type_num
     edge_type_count = [0] * edge_type_num
     node_writer = writers.NodeWriter(str(folder), suffix)
     edge_writer = writers.EdgeWriter(str(folder), suffix)

--- a/src/python/deepgnn/graph_engine/snark/converter/writers.py
+++ b/src/python/deepgnn/graph_engine/snark/converter/writers.py
@@ -1,12 +1,11 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-"""Set of writers to convert graph from json format to binary."""
+"""Set of writers to convert graph from decoded format to binary."""
 import ctypes
 import os
 import tempfile
 import struct
-import sys
 import typing
 
 import numpy as np
@@ -18,8 +17,7 @@ from deepgnn.graph_engine.snark.meta import _Element
 
 
 class NodeWriter:
-    """
-    NodeWriter is an entry point for conversion from euler json files to DeepGNN files.
+    """NodeWriter is an entry point for conversion from input files to node binary files.
 
     Every record is parsed one by one and passed to the relevant writers below. These writers
     put data in files with the partition suffix: `node_{partition}...`. We reserve one more
@@ -43,26 +41,30 @@ class NodeWriter:
         )
         self.count = 0
         self.feature_writer = NodeFeatureWriter(folder, partition)
-        self.edge_writer = EdgeWriter(folder, partition)
 
-    def add(self, node: typing.Any):
+    def add(self, node_id: int, node_type: int, features: list):
         """Write node features and data about edges from this node to binary.
 
         Args:
-            node (typing.Any): dictionary with information about
+            node_id: int
+            node_type: int
+            features: list[ndarray]
         """
-        self.nm.write(ctypes.c_uint64(node["node_id"]))  # type: ignore
-        self.nm.write(ctypes.c_uint64(self.count))  # type: ignore
-        self.nm.write(ctypes.c_int32(node["node_type"]))  # type: ignore
-        self.feature_writer.add(node)
-        self.edge_writer.add(node)
+        self.nm.write(
+            struct.pack(
+                "=QQi",
+                node_id,
+                self.count,
+                node_type,
+            )
+        )
+        self.feature_writer.add(features)
         self.count += 1
 
     def close(self):
         """Close output binary files."""
         self.nm.close()
         self.feature_writer.close()
-        self.edge_writer.close()
 
 
 class NodeFeatureWriter:
@@ -97,25 +99,28 @@ class NodeFeatureWriter:
             ),
             "wb",
         )
+        self.nfd_pos = self.nfd.tell()
 
-    def add(self, node: typing.Any):
+        self.node_feature_num = 0
+
+    def add(self, features: list):
         """Add node to binary output.
 
         Args:
-            node (typing.Any): graph node with all node features and edges from it.
+            features (list): ordered list of feature vectors as ndarrays - or None for an empty vector.
         """
         self.ni.write(ctypes.c_uint64(self.nfi.tell() // 8))  # type: ignore
-        for k in convert_features(node):
+        for k in convert_features(features):
             # Fill the gaps between features
-            self.nfi.write(ctypes.c_uint64(self.nfd.tell()))  # type: ignore
+            self.nfi.write(ctypes.c_uint64(self.nfd_pos))  # type: ignore
             if k is not None:
-                self.nfd.write(k)
+                self.nfd_pos += self.nfd.write(k)
 
     def close(self):
         """Close output binary files."""
         self.ni.write(ctypes.c_uint64(self.nfi.tell() // 8))
         self.ni.close()
-        self.nfi.write(ctypes.c_uint64(self.nfd.tell()))
+        self.nfi.write(ctypes.c_uint64(self.nfd_pos))
         self.nfi.close()
         self.nfd.close()
 
@@ -150,28 +155,36 @@ class EdgeWriter:
             ),
             "wb",
         )
+        self.efi_pos = self.efi.tell()
 
         self.feature_writer = EdgeFeatureWriter(folder, partition, self.efi)
 
-    def add(self, node: typing.Any):
-        """Append edges starting at node to the output.
-
-        Args:
-            node (typing.Any): node with edges data
-        """
+    def add_node(self):
+        """Add node."""
         self.nbi.write(  # type: ignore
             ctypes.c_uint64(self.ei.tell() // (4 + 8 + 8 + 4))
         )  # 4 bytes type, 8 bytes destination, 8 bytes offset, 4 bytes weight
-        edge_list = sorted(
-            node["edge"], key=lambda x: (int(x["edge_type"]), int(x["dst_id"]))
+
+    def add(self, dst: int, tp: int, weight: float, features: list):
+        """Append edges starting at node to the output.
+
+        Args:
+            dst: int
+            tp: int
+            weight: float
+            features: list[ndarray]
+        """
+        # Record order is important for C++ reader: order fields by size for faster load.
+        self.ei.write(
+            struct.pack(
+                "=QQif",
+                dst,
+                self.efi_pos // 8,
+                tp,
+                weight,
+            )
         )
-        for item in edge_list:
-            # Record order is important for C++ reader: order fields by size for faster load.
-            self.ei.write(ctypes.c_uint64(item["dst_id"]))  # type: ignore
-            self.ei.write(ctypes.c_uint64(self.efi.tell() // 8))  # type: ignore
-            self.ei.write(ctypes.c_int32(item["edge_type"]))  # type: ignore
-            self.ei.write(ctypes.c_float(item["weight"]))  # type: ignore
-            self.feature_writer.add(item)
+        self.efi_pos += self.feature_writer.add(features)
 
     def close(self):
         """Close output binary files."""
@@ -179,13 +192,15 @@ class EdgeWriter:
             ctypes.c_uint64(self.ei.tell() // (4 + 8 + 8 + 4))
         )  # type: ignore
         self.nbi.close()
-
-        self.ei.write(ctypes.c_uint64(0))  # type: ignore
-        self.ei.write(ctypes.c_uint64(self.efi.tell() // (8)))  # type: ignore
-
-        self.ei.write(ctypes.c_int32(0))  # type: ignore
-        self.ei.write(ctypes.c_float(-1))  # type: ignore
-
+        self.ei.write(
+            struct.pack(
+                "=QQif",
+                0,
+                self.efi_pos // 8,
+                0,
+                -1,
+            )
+        )
         self.ei.close()
         self.efi.write(ctypes.c_uint64(self.feature_writer.tell()))  # type: ignore
         self.efi.close()
@@ -206,6 +221,7 @@ class EdgeFeatureWriter:
         self.fs, _ = get_fs(folder)
         self.folder = folder
         self.partition = partition
+        self.efi = efi
         self.iteration = 0
         self.efd = self.fs.open(
             meta._get_element_features_data_path(
@@ -213,18 +229,20 @@ class EdgeFeatureWriter:
             ),
             "wb",
         )
-        self.efi = efi
+        self.efd_pos = self.efd.tell()
 
-    def add(self, head: typing.Any):
+    def add(self, features: list):
         """Add edge features the binary output.
 
         Args:
-            head (typing.Dict): collection of float/uint64/binary features.
+            features (list): ordered list of feature vectors as ndarrays - or None for an empty vector.
         """
-        for k in convert_features(head):
-            self.efi.write(ctypes.c_uint64(self.efd.tell()))  # type: ignore
+        features_written = 0
+        for k in convert_features(features):
+            features_written += self.efi.write(ctypes.c_uint64(self.efd_pos))  # type: ignore
             if k is not None:
-                self.efd.write(k)
+                self.efd_pos += self.efd.write(k)
+        return features_written
 
     def tell(self) -> int:
         """Tell start position for the next feature data.
@@ -232,7 +250,7 @@ class EdgeFeatureWriter:
         Returns:
             [int]: Last position in data file.
         """
-        return self.efd.tell()
+        return self.efd_pos
 
     def close(self):
         """Close output files."""
@@ -240,8 +258,7 @@ class EdgeFeatureWriter:
 
 
 class NodeAliasWriter:
-    """
-    NodeAliasWriter creates alias tables for weighted node sampling.
+    """NodeAliasWriter creates alias tables for weighted node sampling.
 
     To avoid using lots of memory it utilizes temp files to store all nodes added to
     it and creates alias tables from them when the writer is closed.
@@ -285,15 +302,16 @@ class NodeAliasWriter:
             for tp in range(node_type_count)
         ]
 
-    def add(self, node: typing.Any):
+    def add(self, node_id: int, tp: int, weight: float):
         """Record node information.
 
         Args:
-            node (typing.Any): Node with information about it's id, type and weight
+            node_id: int
+            tp: int
+            weight: float
         """
-        tp = node["node_type"]
-        self.nodes[tp].write(ctypes.c_uint64(node["node_id"]))
-        self.weights[tp].write(ctypes.c_float(node["node_weight"]))
+        self.nodes[tp].write(ctypes.c_uint64(node_id))  # type: ignore
+        self.weights[tp].write(ctypes.c_float(weight))  # type: ignore
 
     def close(self):
         """Convert temporary files to the final alias tables."""
@@ -329,8 +347,7 @@ class NodeAliasWriter:
 
 
 class EdgeAliasWriter:
-    """
-    EdgeAliasWriter creates alias tables for edges.
+    """EdgeAliasWriter creates alias tables for edges.
 
     These tables can be used for weighted edge sampling with the same pattern
     as NodeAliasWriter. Final files have a fixed record format with following contents:
@@ -375,16 +392,18 @@ class EdgeAliasWriter:
             for tp in range(edge_type_count)
         ]
 
-    def add(self, edge: typing.Dict):
+    def add(self, src: int, dst: int, tp: int, weight: float):
         """Add edge to the alias tables.
 
         Args:
-            edge (typing.Dict): Edge with information about it's source/destination ids, type and weight
+            src: int
+            dst: int
+            tp: int
+            weight: float
         """
-        tp = edge["edge_type"]
-        self.pairs[tp].write(ctypes.c_uint64(edge["src_id"]))  # type: ignore
-        self.pairs[tp].write(ctypes.c_uint64(edge["dst_id"]))  # type: ignore
-        self.weights[tp].write(ctypes.c_float(edge["weight"]))  # type: ignore
+        self.pairs[tp].write(ctypes.c_uint64(src))  # type: ignore
+        self.pairs[tp].write(ctypes.c_uint64(dst))  # type: ignore
+        self.weights[tp].write(ctypes.c_float(weight))  # type: ignore
 
     def close(self):
         """Convert temporary files to the final alias tables."""
@@ -427,81 +446,16 @@ class EdgeAliasWriter:
         self.meta_tmp_folder.cleanup()
 
 
-def __add_sparse(node, feature, tp, container):
-    if feature not in node or node[feature] is None:
-        return
-    for k in node[feature]:
-        values = node[feature][k]["values"]
-        values_buf = (tp * len(values))()
-        values_buf[:] = values
-
-        coordinates = np.array(node[feature][k]["coordinates"], dtype=np.int64)
-        assert int(k) not in container, "Duplicate feature ids found for a node"
-        assert (
-            coordinates.shape[0] == len(values)
-            if len(values) > 1
-            else len(coordinates.shape) == 1
-            or coordinates.shape[0]
-            == 1  # relax input requirements for single values, both [[a,b]] and [a,b] are ok.
-        ), f"Coordinates {coordinates} and values {values} dimensions don't match"
-
-        # For matrices the number of values might be different than number of coordinates
-        # Pack data in the following format: number of coordinates as uint32, then coordinates, and actual values in the end
-        final_buf = (
-            bytes(ctypes.c_uint32(coordinates.size))
-            + bytes(
-                ctypes.c_uint32(coordinates.shape[-1] if coordinates.ndim > 1 else 1)
-            )
-            + bytes(coordinates.data)
-            + values_buf
-        )
-        container[int(k)] = final_buf
-
-
-def __add_dense(node, feature, tp, container):
-    if feature not in node or node[feature] is None:
-        return
-    for k in node[feature]:
-        values = node[feature][k]
-        buf = (tp * len(values))()
-        buf[:] = values
-        assert int(k) not in container, "Duplicate feature ids found for a node"
-        container[int(k)] = buf
-
-
-def __add(node, feature, tp, container):
-    __add_dense(node, feature, tp, container)
-    __add_sparse(node, f"sparse_{feature}", tp, container)
-
-
-def convert_features(node: typing.Any):
+def convert_features(features: list):
     """Convert the node's feature into bytes sorted by index."""
     # Use a single container for all node features to make sure there are unique feature_ids
     # and gaps between feature ids are processed correctly.
-    container: typing.Dict[int, typing.Any] = {}
-    __add(node, "float_feature", ctypes.c_float, container)
-    __add(node, "double_feature", ctypes.c_double, container)
-    __add(node, "uint64_feature", ctypes.c_uint64, container)
-    __add(node, "int64_feature", ctypes.c_int64, container)
-    __add(node, "uint32_feature", ctypes.c_uint32, container)
-    __add(node, "int32_feature", ctypes.c_int32, container)
-    __add(node, "uint16_feature", ctypes.c_uint16, container)
-    __add(node, "int16_feature", ctypes.c_int16, container)
-    __add(node, "uint8_feature", ctypes.c_uint8, container)
-    __add(node, "int8_feature", ctypes.c_int8, container)
-
-    if "float16_feature" in node and node["float16_feature"] is not None:
-        for k in node["float16_feature"]:
-            container[int(k)] = np.array(
-                node["float16_feature"][k], dtype=np.float16
-            ).tobytes()
-
-    if "sparse_float16_feature" in node and node["sparse_float16_feature"] is not None:
-        for k in node["sparse_float16_feature"]:
-            coordinates = np.array(
-                node["sparse_float16_feature"][k]["coordinates"], dtype=np.int64
-            )
-            values = node["sparse_float16_feature"][k]["values"]
+    output = []  # type: ignore
+    for feature in features:
+        if feature is None:
+            output.append(feature)
+        elif isinstance(feature, tuple):
+            coordinates, values = feature
             assert (
                 coordinates.shape[0] == len(values)
                 if len(values) > 1
@@ -510,33 +464,27 @@ def convert_features(node: typing.Any):
                 == 1  # relax input requirements for single values, both [[a,b]] and [a,b] are ok.
             ), f"Coordinates {coordinates} and values {values} dimensions don't match"
 
-            container[int(k)] = (
-                int.to_bytes(
-                    len(coordinates), length=4, signed=True, byteorder=sys.byteorder
-                )
-                + bytes(
-                    struct.pack(
-                        "=I",
-                        ctypes.c_uint32(
-                            coordinates.shape[-1] if coordinates.ndim > 1 else 1
-                        ).value,
-                    )
-                )
-                + bytes(coordinates.data)
-                + np.array(values, dtype=np.float16).tobytes()
+            coordinates_meta = bytes(
+                ctypes.c_uint32(coordinates.shape[-1] if coordinates.ndim > 1 else 1)  # type: ignore
             )
 
-    if "binary_feature" in node and node["binary_feature"] is not None:
-        for k in node["binary_feature"]:
-            container[int(k)] = bytes(node["binary_feature"][k], "utf-8")
+            if values.dtype == np.float16:
+                values_buf = np.array(values, dtype=np.float16).tobytes()
+            else:
+                values_buf = (np.ctypeslib.as_ctypes_type(values.dtype) * len(values))()
+                values_buf[:] = values  # type: ignore
 
-    ret_list = []  # type: ignore
-    curr = 0
-    for k in sorted(container.keys()):
-        while curr < k:
-            ret_list.append(None)
-            curr += 1
-        ret_list.append(container[k])
-        curr += 1
+            # For matrices the number of values might be different than number of coordinates
+            # Pack data in the following format: number of coordinates as uint32, then coordinates, and actual values in the end
+            output.append(
+                bytes(ctypes.c_uint32(coordinates.size))  # type: ignore
+                + coordinates_meta
+                + bytes(coordinates.data)
+                + values_buf
+            )
+        elif isinstance(feature, np.ndarray):
+            output.append(feature.tobytes())
+        else:
+            output.append(bytes(feature, "utf-8"))
 
-    return ret_list
+    return output

--- a/src/python/deepgnn/graph_engine/snark/decoders.py
+++ b/src/python/deepgnn/graph_engine/snark/decoders.py
@@ -4,15 +4,29 @@
 """Decoders wihch is used to decode a line of text into node object."""
 import abc
 import json
-import logging
 import csv
-from typing import Any, Dict, TypeVar
-
-logger = logging.getLogger()
+from typing import TypeVar
+import numpy as np
 
 
 class Decoder(abc.ABC):
     """Interface to convert one line of text into node object."""
+
+    convert_map = {
+        "double_feature": np.float64,
+        "float_feature": np.float32,
+        "float64_feature": np.float64,
+        "float32_feature": np.float32,
+        "float16_feature": np.float16,
+        "uint64_feature": np.uint64,
+        "int64_feature": np.int64,
+        "uint32_feature": np.uint32,
+        "int32_feature": np.int32,
+        "uint16_feature": np.uint16,
+        "int16_feature": np.int16,
+        "uint8_feature": np.uint8,
+        "int8_feature": np.int8,
+    }
 
     @abc.abstractmethod
     def decode(self, line: str):
@@ -52,9 +66,43 @@ class JsonDecoder(Decoder):
         """Initialize the JsonDecoder."""
         super().__init__()
 
+    def _pull_features(self, item: dict) -> list:
+        """From item, pull all value dicts {idx: value} and order the values by idx."""
+        ret_list = []  # type: ignore
+        curr = 0
+        for key, values in item.items():
+            if values is None or "feature" not in key:
+                continue
+
+            for idx, value in values.items():
+                idx = int(idx)
+                while curr <= idx:
+                    ret_list.append(None)
+                    curr += 1
+                if key.startswith("sparse"):
+                    value = (
+                        np.array(value["coordinates"], dtype=np.int64),
+                        np.array(
+                            value["values"],
+                            dtype=self.convert_map[key.replace("sparse_", "")],
+                        ),
+                    )
+                elif key != "binary_feature":
+                    value = np.array(value, dtype=self.convert_map[key])
+                ret_list[idx] = value
+
+        return ret_list
+
     def decode(self, line: str):
         """Use json package to convert the json text line into node object."""
-        return json.loads(line)
+        data = json.loads(line) if isinstance(line, str) else line
+        yield -1, data["node_id"], data["node_type"], data[
+            "node_weight"
+        ], self._pull_features(data)
+        for edge in data["edge"]:
+            yield edge["src_id"], edge["dst_id"], edge["edge_type"], edge[
+                "weight"
+            ], self._pull_features(edge)
 
 
 class TsvDecoder(Decoder):
@@ -76,7 +124,6 @@ class TsvDecoder(Decoder):
                         e.g. f:0.1 0.2;b:stringfeatures;i:1 2 3;i16: 1 2 3;u32: 1 2 3
         neighbors:      (dst_id,edge_type,edge_weight,edge_label,edge_features|dst_id,edge_type,edge_weight,edge_label,edge_features|...)
                         e.g. 2, 0, 0.3, 1, 0.1 0.2:stringfeatures:1 2 3|3, 1, 0.4, 2, 0.1 0.2:stringfeatures:4 5 6|...
-
     Example:
             | node_id | node_type | node_weight | node_features                | neighbors                                  |
             | --------|-----------|-------------|------------------------------|--------------------------------------------|
@@ -88,38 +135,33 @@ class TsvDecoder(Decoder):
         super().__init__()
 
     def _parse_feature_string(self, raw_feature):
-        index = 0
-        feature_map: Dict[str, Any] = dict()
+        feature_map = []
         node_features = raw_feature.split(";") if raw_feature else []
         for feature in node_features:
             val = feature.split(":")
-            if len(val) == 2 and val[0] and val[1]:
-                if val[0][0] == "i":
-                    key = f"int{val[0][1:]}_feature"
-                    if key not in feature_map:
-                        feature_map[key] = dict()
-                    feature_map[key][str(index)] = [int(i) for i in val[1].split(" ")]
-                elif val[0][0] == "u":
-                    key = f"uint{val[0][1:]}_feature"
-                    if key not in feature_map:
-                        feature_map[key] = dict()
-                    feature_map[key][str(index)] = [int(i) for i in val[1].split(" ")]
-                elif val[0][0] == "f":
-                    key = f"float{val[0][1:]}_feature"
-                    if key not in feature_map:
-                        feature_map[key] = dict()
-                    feature_map[key][str(index)] = [float(i) for i in val[1].split(" ")]
-                elif val[0][0] == "d":
-                    key = "double_feature"
-                    if key not in feature_map:
-                        feature_map[key] = dict()
-                    feature_map[key][str(index)] = [float(i) for i in val[1].split(" ")]
-                elif val[0][0] == "b":
-                    key = "binary_feature"
-                    feature_map[key] = dict()
-                    feature_map[key][str(index)] = val[1]
+            if len(val) != 2 or not val[0] or not val[1]:
+                feature_map.append(None)
+                continue
 
-            index = index + 1
+            if val[0][0] == "i":
+                key = f"int{val[0][1:]}_feature"
+            elif val[0][0] == "u":
+                key = f"uint{val[0][1:]}_feature"
+            elif val[0][0] == "f":
+                key = f"float{val[0][1:]}_feature"
+            elif val[0][0] == "d":
+                key = "double_feature"
+            elif val[0][0] == "b":
+                key = "binary_feature"
+
+            if len(val) != 2 or not val[0] or not val[1]:
+                value = None
+            elif key != "binary_feature":
+                value = np.array(val[1].split(" "), dtype=self.convert_map[key])
+            else:
+                value = val[1]
+
+            feature_map.append(value)
 
         return feature_map
 
@@ -133,50 +175,30 @@ class TsvDecoder(Decoder):
         for i in range(TsvDecoder.COLUMN_COUNT - len(columns)):
             columns.append("")
 
-        node: Dict[str, Any] = dict()
-
         # make sure the node id is valid
         assert columns[0] is not None and len(columns[0]) > 0
-        node["node_id"] = int(columns[0])
-        node["node_type"] = int(columns[1]) if columns[1] else 0
-        node["node_weight"] = float(columns[2]) if columns[2] else 0.0
+        node_id = int(columns[0])
+        node_type = int(columns[1]) if columns[1] else 0
+        node_weight = float(columns[2]) if columns[2] else 0.0
+        yield -1, node_id, node_type, node_weight, self._parse_feature_string(
+            columns[3]
+        )
 
-        # index 1 of the float feature is node float feature.
-        feature_map = self._parse_feature_string(columns[3])
-        node.update(feature_map)
+        if not columns[4]:
+            return
 
-        node["neighbor"] = dict()
-        node["edge"] = []
-        if columns[4]:
-            neighbors = columns[4].split("|")
-            for n in neighbors:
-                neighbor_columns = n.split(",")
-                # make sure the destination id is valid
-                assert len(neighbor_columns) > 0 and len(neighbor_columns[0]) > 0
-                dst_id = int(neighbor_columns[0])
+        neighbors = columns[4].split("|")
+        for n in neighbors:
+            neighbor_columns = n.split(",")
+            # make sure the destination id is valid
+            assert len(neighbor_columns) > 0 and len(neighbor_columns[0]) > 0
+            dst_id = int(neighbor_columns[0])
 
-                for i in range(
-                    TsvDecoder.NEIGHBOR_COLUMN_COUNT - len(neighbor_columns)
-                ):
-                    neighbor_columns.append("")
+            for i in range(TsvDecoder.NEIGHBOR_COLUMN_COUNT - len(neighbor_columns)):
+                neighbor_columns.append("")
 
-                dst_type = int(neighbor_columns[1]) if neighbor_columns[1] else 0
-                dst_weight = float(neighbor_columns[2]) if neighbor_columns[2] else 0.0
-
-                if dst_type not in node["neighbor"]:
-                    node["neighbor"][str(dst_type)] = dict()
-
-                node["neighbor"][str(dst_type)][str(dst_id)] = dst_weight
-
-                edge_info = dict()
-                edge_info["src_id"] = node["node_id"]
-                edge_info["dst_id"] = dst_id
-                edge_info["edge_type"] = dst_type
-                edge_info["weight"] = dst_weight
-
-                feature_map = self._parse_feature_string(neighbor_columns[3])
-                edge_info.update(feature_map)
-
-                node["edge"].append(edge_info)
-
-        return node
+            dst_type = int(neighbor_columns[1]) if neighbor_columns[1] else 0
+            dst_weight = float(neighbor_columns[2]) if neighbor_columns[2] else 0.0
+            yield node_id, dst_id, dst_type, dst_weight, self._parse_feature_string(
+                neighbor_columns[3]
+            )


### PR DESCRIPTION
* Make Decoder.decode a generator that yields a node then its outgoing edges in order. Yield format is (-1/src, node_id/dst, type, weight, features), with features being a list of dense features as ndarrays and sparse features as 2 tuples, coordinates and values.
* Reduce a lot of work to create "node" objects in decoders then unravel them in writers.
* Split up writers to support node and edges being yielded separately - but still require node first then its outgoing edges.
* Update return type for features in a way that is almost ready to write to file.
* Writers reduce file.tell() usage since is slow - replace with counters.