### PR TITLE
[BUG FIX]: Dropped Indexing for 2-hop neighbor_feats

### DIFF
--- a/src/python/deepgnn/pytorch/encoding/gnn_encoder_sage.py
+++ b/src/python/deepgnn/pytorch/encoding/gnn_encoder_sage.py
@@ -87,7 +87,7 @@ class SageEncoder(nn.Module):
         if isinstance(neigh_feats_unique, dict):
             context["neighbor_feats"] = {
                 "node_feats": neigh_feats_unique["node_feats"][idx],
-                "neighbor_feats": neigh_feats_unique["neighbor_feats"][idx],
+                "neighbor_feats": neigh_feats_unique["neighbor_feats"],
                 "node_count": idx.size,
             }
         else:


### PR DESCRIPTION
Bug Description: Previously, indices `idx` (output of numpy.unique) of 1-hop neighbors (i.e. `neigh_feats_unique` computed on Line 83) were being used to reconstruct features of 2-hop neighbors (i.e. `neigh_feats_unique["neighbor_feats"]` computed on Line 90); this results in slicing of feature matrix for 2-hop neighbors.

This change drops the indexing on Line 90.



Steps to reproduce:
(Dataset: Cora; Fanout: [10, 10]; Batch-Size: 140; Sampling: RandomWithoutReplacement)

Before this code change:

```
>>> context['encoder']['node_feats']['node_feats'].shape
(140, 50)

>>> context['encoder']['node_feats']['neighbor_feats'].shape
(1400, 50)

>>> context['encoder']['neighbor_feats']['node_feats'].shape
(1400, 50)

>>> context['encoder']['neighbor_feats']['neighbor_feats'].shape
(1400, 50)
```

After this code change:

```
>>> context['encoder']['node_feats']['node_feats'].shape
(140, 50)

>>> context['encoder']['node_feats']['neighbor_feats'].shape
(1400, 50)

>>> context['encoder']['neighbor_feats']['node_feats'].shape
(1400, 50)

>>> context['encoder']['neighbor_feats']['neighbor_feats'].shape
(4160, 50)
```

- [ ] Forked repo is synced with upstream -> github shows no code delta outside of the desired.
    https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork
- [ ] Tests are passing? https://github.com/microsoft/DeepGNN/blob/main/CONTRIBUTING.md#run-tests
- [ ] Documentation is added or updated to reflect new code in the same format as the rest of the repo.
- [ ] PR is labeled using the label menu on the right side.

Previous Behavior
----------------
* Provide relevant issue number if applicable, eg #44.

New Behavior
----------------
