### PR TITLE
CI pipeline no longer use python 3.7 -> [3.8, 3.9].

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
     needs: pre-commit
     strategy:
       matrix:
-        python-version: ["3.7", "3.8"]
+        python-version: ["3.8", "3.9"]
         os: ["ubuntu-latest", "macos-11", "windows-2019"]
     runs-on: ${{ matrix.os }}
     steps:
@@ -77,7 +77,7 @@ jobs:
     needs: wheel
     strategy:
       matrix:
-        python-version: ["3.7", "3.8"]
+        python-version: ["3.8", "3.9"]
         os: ["ubuntu-latest", "ubuntu-18.04"]
     runs-on: ${{ matrix.os }}
     env:
@@ -121,7 +121,7 @@ jobs:
     needs: wheel
     strategy:
       matrix:
-        python-version: ["3.7", "3.8"]
+        python-version: ["3.8", "3.9"]
         os: ["ubuntu-latest", "ubuntu-18.04"]
     runs-on: ${{ matrix.os }}
     env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     if: ${{ github.event.workflow_run == null || github.event.workflow_run.conclusion == 'success'}}
     strategy:
       matrix:
-        python-version: ["3.7", "3.8"]
+        python-version: ["3.8", "3.9"]
         os: ["ubuntu-latest", "macos-11", "windows-2019"]
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
- [x] Forked repo is synced with upstream -> github shows no code delta outside of the desired.
    https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork
- [x] Tests are passing? https://github.com/microsoft/DeepGNN/blob/main/CONTRIBUTING.md#run-tests
- [x] Documentation is added or updated to reflect new code in the same format as the rest of the repo.
- [x] PR is labeled using the label menu on the right side.

Previous Behavior
----------------
CI pipeline runs tests in 3.7 which causes dependency errors.

New Behavior
----------------
CI pipeline now runs tests in 3.8 and 3.9 only.