### PR TITLE
Fix disconnected computational graph

### DIFF
--- a/examples/pytorch/graphsage/test_model.py
+++ b/examples/pytorch/graphsage/test_model.py
@@ -293,6 +293,45 @@ def test_supervised_graphsage_model(mock_graph):  # noqa: F811
     npt.assert_allclose(output.detach().numpy(), expected, rtol=1e-3)
 
 
+# test if computational graph is connected.
+def test_supervised_graphsage_computational_graph(mock_graph):  # noqa: F811
+    np.random.seed(0)
+    torch.manual_seed(0)
+
+    num_classes = 7
+    label_dim = 7
+    label_idx = 1
+    feature_dim = 1433
+    feature_idx = 0
+    edge_type = 0
+
+    graphsage = SupervisedGraphSage(
+        num_classes=num_classes,
+        metric=F1Score(),
+        label_idx=label_idx,
+        label_dim=label_dim,
+        feature_type=FeatureType.FLOAT,
+        feature_idx=feature_idx,
+        feature_dim=feature_dim,
+        edge_type=edge_type,
+        fanouts=[5, 5],
+    )
+
+    # use one batch to verify if computational graph is connected.
+    simpler = MockSimpleDataLoader(
+        batch_size=256, query_fn=graphsage.query, graph=mock_graph
+    )
+
+    it = iter(simpler)
+    context = it.next()
+
+    # here we are using feature tensor as a proxy for node ids
+    assert np.array_equal(
+        context["encoder"]["node_feats"]["neighbor_feats"],
+        context["encoder"]["neighbor_feats"]["node_feats"],
+    )
+
+
 # test the correctness of the loss function.
 def test_supervised_graphsage_loss_value(mock_graph):  # noqa: F811
     np.random.seed(0)

--- a/examples/pytorch/graphsage/test_model.py
+++ b/examples/pytorch/graphsage/test_model.py
@@ -318,15 +318,14 @@ def test_supervised_graphsage_computational_graph(mock_graph):  # noqa: F811
     )
 
     # use one batch to verify if computational graph is connected.
-    simpler = MockSimpleDataLoader(
-        batch_size=256, query_fn=graphsage.query, graph=mock_graph
+    trainloader = torch.utils.data.DataLoader(
+        MockSimpleDataLoader(batch_size=256, query_fn=graphsage.query, graph=mock_graph)
     )
-
-    it = iter(simpler)
+    it = iter(trainloader)
     context = it.next()
 
     # here we are using feature tensor as a proxy for node ids
-    assert np.array_equal(
+    assert torch.equal(
         context["encoder"]["node_feats"]["neighbor_feats"],
         context["encoder"]["neighbor_feats"]["node_feats"],
     )

--- a/src/python/deepgnn/pytorch/encoding/gnn_encoder_sage.py
+++ b/src/python/deepgnn/pytorch/encoding/gnn_encoder_sage.py
@@ -73,13 +73,18 @@ class SageEncoder(nn.Module):
         """Query graph for training data."""
         context = {}
         if neigh_nodes is None:
-            neigh_nodes = graph.sample_neighbors(nodes, self.edge_types, self.num_sample)[
-                0
-            ].flatten()
+            neigh_nodes = graph.sample_neighbors(
+                nodes, self.edge_types, self.num_sample
+            )[0].flatten()
         neigh_nodes_unique, idx = np.unique(neigh_nodes, return_inverse=True)
 
         context["node_feats"] = self.query_func(
-            nodes, graph, feature_type, feature_idx, feature_dim, neigh_nodes=neigh_nodes,
+            nodes,
+            graph,
+            feature_type,
+            feature_idx,
+            feature_dim,
+            neigh_nodes=neigh_nodes,
         )
 
         neigh_feats_unique = self.query_func(

--- a/src/python/deepgnn/pytorch/encoding/gnn_encoder_sage.py
+++ b/src/python/deepgnn/pytorch/encoding/gnn_encoder_sage.py
@@ -68,16 +68,18 @@ class SageEncoder(nn.Module):
         feature_type: FeatureType,
         feature_idx: int,
         feature_dim: int,
+        neigh_nodes: np.ndarray = None,
     ):
         """Query graph for training data."""
         context = {}
-        neigh_nodes = graph.sample_neighbors(nodes, self.edge_types, self.num_sample)[
-            0
-        ].flatten()
+        if neigh_nodes is None:
+            neigh_nodes = graph.sample_neighbors(nodes, self.edge_types, self.num_sample)[
+                0
+            ].flatten()
         neigh_nodes_unique, idx = np.unique(neigh_nodes, return_inverse=True)
 
         context["node_feats"] = self.query_func(
-            nodes, graph, feature_type, feature_idx, feature_dim
+            nodes, graph, feature_type, feature_idx, feature_dim, neigh_nodes=neigh_nodes,
         )
 
         neigh_feats_unique = self.query_func(
@@ -107,6 +109,7 @@ class SageEncoder(nn.Module):
         feature_type: FeatureType,
         feature_idx: int,
         feature_dim: int,
+        neigh_nodes: np.ndarray = None,
     ):
         """Fetch features."""
         features = graph.node_features(


### PR DESCRIPTION
Presently, neigh_nodes are sampled twice (once on Line 74 and a second time when query_func is invoked on Line 79), this results in a disconnected graph.

Before this change:

```
>>> numpy.array_equal(context['encoder']['node_feats']['neighbor_feats'], context['encoder']['neighbor_feats']['node_feats'])
False
```

After this change:

```
>>> numpy.array_equal(context['encoder']['node_feats']['neighbor_feats'], context['encoder']['neighbor_feats']['node_feats'])
True
```