### PR TITLE
Fix dimensions in sparse features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.1 DeepGNN
 
+## 0.1.52 - 2022-07-27
+
 * Rename and move convert.output to converter.process.converter_process. Dispatchers make argument 'process' default to converter.process.converter_process. Dispatchers move process argument after decoder_type.
 
 * Replace converter and dispatcher's argument "decoder_type" -> "decoder" that accepts Decoder object directly instead of DecoderType enum. Replace DecoderType enum with type hint.
@@ -11,3 +13,5 @@
 * Add BinaryWriter as new entry point for NodeWriter, EdgeWriter and alias writers.
 
 * Meta.json files are no longer needed by the converter. Remove meta path argument from MultiWorkerConverter and Dispatchers.
+
+* Bugfix: fill dimensions with 0 for missing features.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.1 DeepGNN
 
-## 0.1.52 - 2022-07-27
+### 0.1.52 - 2022-07-27
 
 * Rename and move convert.output to converter.process.converter_process. Dispatchers make argument 'process' default to converter.process.converter_process. Dispatchers move process argument after decoder_type.
 

--- a/src/cc/lib/distributed/client.cc
+++ b/src/cc/lib/distributed/client.cc
@@ -364,6 +364,11 @@ void GRPCClient::GetNodeSparseFeature(std::span<const NodeId> node_ids, std::spa
                                       std::span<int64_t> out_dimensions, std::vector<std::vector<int64_t>> &out_indices,
                                       std::vector<std::vector<uint8_t>> &out_values)
 {
+    assert(out_indices.size() == features.size());
+    assert(out_dimensions.size() == features.size());
+
+    // Fill out_dimensions in case nodes don't have some features.
+    std::fill(std::begin(out_dimensions), std::end(out_dimensions), 0);
     NodeSparseFeaturesRequest request;
     *request.mutable_node_ids() = {std::begin(node_ids), std::end(node_ids)};
     *request.mutable_feature_ids() = {std::begin(features), std::end(features)};

--- a/src/cc/lib/graph/graph.cc
+++ b/src/cc/lib/graph/graph.cc
@@ -141,6 +141,8 @@ void Graph::GetNodeSparseFeature(std::span<const NodeId> node_ids, std::span<con
     assert(features.size() == out_indices.size());
     assert(features.size() == out_data.size());
 
+    // Fill out_dimensions in case nodes don't have some features.
+    std::fill(std::begin(out_dimensions), std::end(out_dimensions), 0);
     const int64_t len = node_ids.size();
     for (int64_t node_index = 0; node_index < len; ++node_index)
     {

--- a/src/cc/tests/graph_test.cc
+++ b/src/cc/tests/graph_test.cc
@@ -527,6 +527,86 @@ TEST_P(StorageTypeGraphTest, NodeSparseFeaturesMissingFeature)
     EXPECT_EQ(std::vector<int64_t>({3}), dimensions);
 }
 
+TEST_P(StorageTypeGraphTest, NodeSparseFeaturesDimensionsFill)
+{
+    // indices - 17416, data - 1.0
+    std::vector<int32_t> f5_data = {1, 1, 17416, 0, 1065353216};
+    auto f5_start = reinterpret_cast<float *>(f5_data.data());
+    // indices - 1, data - 1.0
+    std::vector<int32_t> f6_data = {1, 1, 0, 0, 1065353216};
+    auto f6_start = reinterpret_cast<float *>(f6_data.data());
+
+    std::vector<std::vector<float>> input_features = {{},
+                                                      {},
+                                                      {},
+                                                      {},
+                                                      {},
+                                                      std::vector<float>(f5_start, f5_start + f5_data.size()),
+                                                      std::vector<float>(f6_start, f6_start + f6_data.size())};
+    TestGraph::MemoryGraph m;
+    m.m_nodes.push_back(TestGraph::Node{
+        .m_id = snark::NodeId(13979298), .m_type = 0, .m_weight = 1.0f, .m_float_features = std::move(input_features)});
+    auto path = std::filesystem::temp_directory_path();
+    auto partition = TestGraph::convert(path, "0_0", std::move(m), 1);
+    snark::Graph g(path.string(), std::vector<uint32_t>{0}, GetParam(), "");
+
+    std::vector<snark::NodeId> nodes = {13979298};
+    std::vector<snark::FeatureId> features = {6};
+
+    std::vector<std::vector<uint8_t>> data(features.size());
+    std::vector<std::vector<int64_t>> indices(features.size());
+    std::vector<int64_t> dimensions = {-1};
+    g.GetNodeSparseFeature(std::span(nodes), std::span(features), std::span(dimensions), indices, data);
+    EXPECT_EQ(std::vector<int64_t>({0, 0}), indices[0]);
+    EXPECT_EQ(std::vector<int64_t>({1}), dimensions);
+    auto tmp = reinterpret_cast<float *>(data[0].data());
+    EXPECT_EQ(std::vector<float>({1.0}), std::vector<float>(tmp, tmp + 1));
+
+    features = {1, 6};
+
+    data = {{}, {}};
+    indices = {{}, {}};
+    dimensions = {-1, -1};
+    g.GetNodeSparseFeature(std::span(nodes), std::span(features), std::span(dimensions), indices, data);
+    EXPECT_EQ(std::vector<int64_t>({}), indices[0]);
+    EXPECT_EQ(std::vector<int64_t>({0, 0}), indices[1]);
+    EXPECT_EQ(std::vector<int64_t>({0, 1}), dimensions);
+    tmp = reinterpret_cast<float *>(data[1].data());
+    EXPECT_EQ(std::vector<float>({1.0}), std::vector<float>(tmp, tmp + 1));
+
+    features = {1, 2, 5, 6};
+    data = {{}, {}, {}, {}};
+    indices = {{}, {}, {}, {}};
+    dimensions = {-1, -1, -1, -1};
+    g.GetNodeSparseFeature(std::span(nodes), std::span(features), std::span(dimensions), indices, data);
+    EXPECT_EQ(std::vector<int64_t>({}), indices[0]);
+    EXPECT_EQ(std::vector<int64_t>({}), indices[1]);
+    EXPECT_EQ(std::vector<int64_t>({0, 17416}), indices[2]);
+    EXPECT_EQ(std::vector<int64_t>({0, 0}), indices[3]);
+    EXPECT_EQ(std::vector<int64_t>({0, 0, 1, 1}), dimensions);
+    EXPECT_EQ(0, data[0].size());
+    EXPECT_EQ(0, data[1].size());
+    tmp = reinterpret_cast<float *>(data[2].data());
+    EXPECT_EQ(std::vector<float>({1.0}), std::vector<float>(tmp, tmp + 1));
+    tmp = reinterpret_cast<float *>(data[3].data());
+    EXPECT_EQ(std::vector<float>({1.0}), std::vector<float>(tmp, tmp + 1));
+
+    features = {5, 6};
+    data = {{}, {}};
+    indices = {{}, {}};
+    dimensions = {-1, -1};
+    g.GetNodeSparseFeature(std::span(nodes), std::span(features), std::span(dimensions), indices, data);
+    EXPECT_EQ(std::vector<int64_t>({0, 17416}), indices[0]);
+    EXPECT_EQ(std::vector<int64_t>({0, 0}), indices[1]);
+    EXPECT_EQ(std::vector<int64_t>({1, 1}), dimensions);
+    EXPECT_EQ(sizeof(float), data[0].size());
+    EXPECT_EQ(sizeof(float), data[1].size());
+    tmp = reinterpret_cast<float *>(data[0].data());
+    EXPECT_EQ(std::vector<float>({1.0}), std::vector<float>(tmp, tmp + 1));
+    tmp = reinterpret_cast<float *>(data[1].data());
+    EXPECT_EQ(std::vector<float>({1.0}), std::vector<float>(tmp, tmp + 1));
+}
+
 TEST_P(StorageTypeGraphTest, NodeStringFeaturesMultipleNodesSingleFeature)
 {
     TestGraph::MemoryGraph m;


### PR DESCRIPTION
- [x] Forked repo is synced with upstream -> github shows no code delta outside of the desired.
    https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork
- [x] Tests are passing? https://github.com/microsoft/DeepGNN/blob/main/CONTRIBUTING.md#run-tests
- [x] Documentation is added or updated to reflect new code in the same format as the rest of the repo.
- [x] PR is labeled using the label menu on the right side.

Previous Behavior
----------------
Dimensions of sparse features were not filled with 0s, so if some features were missing for nodes in a partition, we overwrite it with 0 and return garbled results, because dimensions are used later to parse feature data.

New Behavior
----------------
Initialize dimensions with 0s in memory and distributed graph.