### PR TITLE
Fix links in examples readmes

### DIFF
--- a/examples/pytorch/gat/README.md
+++ b/examples/pytorch/gat/README.md
@@ -16,7 +16,7 @@ Graph attention networks (GATs) is a novel neural network architectures that ope
 | Cora     | 83.0          | 83.0 (+/-0.5)    |
 
 # Generate Graph Data
-* [Prepare Graph Data](../../../docs/advanced/data_spec.md)
+* [Prepare Graph Data](../../../docs/graph_engine/data_spec.rst)
 
 # Job Augmentations
 ## GAT

--- a/examples/pytorch/graphsage/README.md
+++ b/examples/pytorch/graphsage/README.md
@@ -4,7 +4,7 @@ __GraphSAGE__ is a framework for inductive representation learning on large grap
 Reference: [Inductive Representation Learning on Large Graphs](https://cs.stanford.edu/people/jure/pubs/graphsage-nips17.pdf)
 
 # Generate Graph Data
-* [Prepare Graph Data](../../../docs/advanced/data_spec.md)
+* [Prepare Graph Data](../../../docs/graph_engine/data_spec.rst)
 
 # Job Augmentations
 ## GraphSAGE - Unsupervised

--- a/examples/pytorch/hetgnn/README.md
+++ b/examples/pytorch/hetgnn/README.md
@@ -7,7 +7,7 @@ HetGNN first introduces a random walk with restart strategy to sample a fixed si
 Reference: [Heterogeneous Graph Neural Network](https://www3.nd.edu/~dial/publications/zhang_2019_heterogeneous.pdf)
 
 # Generate Graph Data
-* [Prepare Graph Data](../../../docs/advanced/data_spec.md)
+* [Prepare Graph Data](../../../docs/graph_engine/data_spec.rst)
 
 # Job Augmentations
 ## HetGNN

--- a/examples/pytorch/knowledgegraph/README.md
+++ b/examples/pytorch/knowledgegraph/README.md
@@ -8,7 +8,7 @@ RotatE [Paper](https://arxiv.org/abs/1902.10197)
 # Generate Graph Data
 pytorch/data/tools/convert_kg_to_json.py: convert standard knowledge graph data to deepgnn json format.
 pytorch/data/tools/produce_test_file.py: generate sample file for evaluation.
-* [Prepare Graph Data](../../../docs/advanced/data_spec.md)
+* [Prepare Graph Data](../../../docs/graph_engine/data_spec.rst)
 
 # Job Augmentations
 ## GAT

--- a/examples/pytorch/link_prediction/README.md
+++ b/examples/pytorch/link_prediction/README.md
@@ -26,7 +26,7 @@ Training steps:
 
 
 # Generate Graph Data
-* [Prepare Graph Data](../../../docs/advanced/data_spec.md)
+* [Prepare Graph Data](../../../docs/graph_engine/data_spec.rst)
 
 * Prepare training data
 

--- a/examples/tensorflow/gat/README.md
+++ b/examples/tensorflow/gat/README.md
@@ -33,4 +33,4 @@ python3 /examples/tensorflow/gat/main.py --mode evaluate --seed 123 --model_dir 
 ```
 
 ### Run GAT with your graph
-* [Prepare Graph Data](../../../docs/advanced/data_spec.md)
+* [Prepare Graph Data](../../../docs/graph_engine/data_spec.rst)

--- a/examples/tensorflow/gcn/README.md
+++ b/examples/tensorflow/gcn/README.md
@@ -24,4 +24,4 @@ Training time: (200 epochs)
 * GPU: P100 16GB
 
 ### Run GCN with your graph
-* [Prepare Graph Data](../../../docs/advanced/data_spec.md)
+* [Prepare Graph Data](../../../docs/graph_engine/data_spec.rst)

--- a/examples/tensorflow/han/README.md
+++ b/examples/tensorflow/han/README.md
@@ -2,7 +2,7 @@
 Reference: [Paper](https://arxiv.org/pdf/1903.07293).
 
 # Generate Graph Data
-* [Prepare Graph Data](../../../docs/advanced/data_spec.md)
+* [Prepare Graph Data](../../../docs/graph_engine/data_spec.rst)
 
 # Job Augmentations
 ## HAN

--- a/examples/tensorflow/sage/README.md
+++ b/examples/tensorflow/sage/README.md
@@ -9,4 +9,4 @@ see [run.sh](./run.sh)
 
 
 ### Run GraphSage with your graph
-* [Prepare Graph Data](../../../docs/advanced/data_spec.md)
+* [Prepare Graph Data](../../../docs/graph_engine/data_spec.rst)


### PR DESCRIPTION
- [x] Forked repo is synced with upstream -> github shows no code delta outside of the desired.
    https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork
- [x] Tests are passing? https://github.com/microsoft/DeepGNN/blob/main/CONTRIBUTING.md#run-tests
- [x] Documentation is added or updated to reflect new code in the same format as the rest of the repo.
- [x] PR is labeled using the label menu on the right side.

Previous Behavior
----------------
* https://github.com/microsoft/DeepGNN/issues/63

New Behavior
----------------

Links point to correct documents. Unfortunately, we don't create docs for examples yet, so we can't automatically verify links in them in CI.