### PR TITLE
Sort edges by type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.1.53] - 2022-08-02
 
 ### Fixed
-- json/tsv converter didn't sort edges by types resulted in incorrect sampling.
+- JSON/TSV converter didn't sort edges by types resulted in incorrect sampling.
 
 ## [0.1.52] - 2022-07-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,24 +1,30 @@
-# DeepGNN Changelog
+# Changelog
+All notable changes to this project will be documented in this file.
 
-## 0.1 DeepGNN
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-### [Unreleased]
+## [Unreleased]
 
-### [0.1.53] - 2022-08-02
+## [0.1.53] - 2022-08-02
 
-#### Fixed
+### Fixed
 - json/tsv converter didn't sort edges by types resulted in incorrect sampling.
 
-### [0.1.52] - 2022-07-27
+## [0.1.52] - 2022-07-27
 
-* Rename and move convert.output to converter.process.converter_process. Dispatchers make argument 'process' default to converter.process.converter_process. Dispatchers move process argument after decoder_type.
+### Changed
+- Rename and move convert.output to converter.process.converter_process. Dispatchers make argument 'process' default to converter.process.converter_process. Dispatchers move process argument after decoder_type.
 
-* Replace converter and dispatcher's argument "decoder_type" -> "decoder" that accepts Decoder object directly instead of DecoderType enum. Replace DecoderType enum with type hint.
+- Replace converter and dispatcher's argument "decoder_type" -> "decoder" that accepts Decoder object directly instead of DecoderType enum. Replace DecoderType enum with type hint.
 
-* Make Decoder.decode a generator that yields a node then its outgoing edges in order. The yield format for nodes/edges is (node_id/src, -1/dst, type, weight, features), with features being a list of dense features as ndarrays and sparse features as 2 tuples, coordinates and values.
+- Make Decoder.decode a generator that yields a node then its outgoing edges in order. The yield format for nodes/edges is (node_id/src, -1/dst, type, weight, features), with features being a list of dense features as ndarrays and sparse features as 2 tuples, coordinates and values.
 
-* Add BinaryWriter as new entry point for NodeWriter, EdgeWriter and alias writers.
+### Added
+- Add BinaryWriter as new entry point for NodeWriter, EdgeWriter and alias writers.
 
-* Meta.json files are no longer needed by the converter. Remove meta path argument from MultiWorkerConverter and Dispatchers.
+### Removed
+- Meta.json files are no longer needed by the converter. Remove meta path argument from MultiWorkerConverter and Dispatchers.
 
-* Bugfix: fill dimensions with 0 for missing features.
+### Fixed
+- Fill dimensions with 0 for missing features.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,14 @@
 
 ## 0.1 DeepGNN
 
-### 0.1.52 - 2022-07-27
+### [Unreleased]
+
+### [0.1.53] - 2022-08-02
+
+#### Fixed
+- json/tsv converter didn't sort edges by types resulted in incorrect sampling.
+
+### [0.1.52] - 2022-07-27
 
 * Rename and move convert.output to converter.process.converter_process. Dispatchers make argument 'process' default to converter.process.converter_process. Dispatchers move process argument after decoder_type.
 

--- a/src/python/deepgnn/graph_engine/snark/decoders.py
+++ b/src/python/deepgnn/graph_engine/snark/decoders.py
@@ -109,7 +109,7 @@ class JsonDecoder(Decoder):
         yield data["node_id"], -1, data["node_type"], data[
             "node_weight"
         ], self._pull_features(data)
-        for edge in data["edge"]:
+        for edge in sorted(data["edge"], key=lambda x: x["edge_type"]):
             yield edge["src_id"], edge["dst_id"], edge["edge_type"], edge[
                 "weight"
             ], self._pull_features(edge)
@@ -204,7 +204,7 @@ class TsvDecoder(Decoder):
             return
 
         neighbors = columns[4].split("|")
-        for n in neighbors:
+        for n in sorted(neighbors, key=lambda x: int(x.split(",")[1])):
             neighbor_columns = n.split(",")
             # make sure the destination id is valid
             assert len(neighbor_columns) > 0 and len(neighbor_columns[0]) > 0

--- a/src/python/deepgnn/graph_engine/snark/tests/convert_test.py
+++ b/src/python/deepgnn/graph_engine/snark/tests/convert_test.py
@@ -719,6 +719,7 @@ def test_sanity_edge_sparse_features_data(graph_with_sparse_features):
             np.frombuffer(result[386:expected_size], dtype=np.float32), [5.5, 6.7]
         )
 
+
 def graph_with_inverse_edge_type_order_json(folder):
     data = open(os.path.join(folder, "graph.json"), "w+")
     graph = [
@@ -738,7 +739,7 @@ def graph_with_inverse_edge_type_order_json(folder):
                     "dst_id": 2,
                     "edge_type": 0,
                     "weight": 0.5,
-                }
+                },
             ],
         },
     ]
@@ -750,12 +751,14 @@ def graph_with_inverse_edge_type_order_json(folder):
 
     return data.name
 
+
 def graph_with_inverse_edge_type_order_tsv(folder):
     data = open(os.path.join(folder, "graph.tsv"), "w+")
     data.write("9\t0\t1\tf:0 1;f:-0.01 -0.02\t1,3,1.0|2,0,0.5\n")
     data.flush()
     data.close()
     return data.name
+
 
 @pytest.fixture(scope="module")
 def graph_with_inverse_edge_type_order(request):
@@ -769,6 +772,7 @@ def graph_with_inverse_edge_type_order(request):
 
     yield data_name, request.param
     workdir.cleanup()
+
 
 @pytest.mark.parametrize("graph_with_inverse_edge_type_order", param, indirect=True)
 def test_edge_index_inverted_types(graph_with_inverse_edge_type_order):
@@ -798,6 +802,7 @@ def test_edge_index_inverted_types(graph_with_inverse_edge_type_order):
         assert result[56:64] == (0).to_bytes(8, byteorder=sys.byteorder)
         assert result[64:68] == (0).to_bytes(4, byteorder=sys.byteorder)
         assert result[68:72] == struct.pack("f", -1)
+
 
 if __name__ == "__main__":
     sys.exit(

--- a/src/python/deepgnn/graph_engine/snark/tests/convert_test.py
+++ b/src/python/deepgnn/graph_engine/snark/tests/convert_test.py
@@ -719,6 +719,85 @@ def test_sanity_edge_sparse_features_data(graph_with_sparse_features):
             np.frombuffer(result[386:expected_size], dtype=np.float32), [5.5, 6.7]
         )
 
+def graph_with_inverse_edge_type_order_json(folder):
+    data = open(os.path.join(folder, "graph.json"), "w+")
+    graph = [
+        {
+            "node_id": 9,
+            "node_type": 0,
+            "node_weight": 1,
+            "edge": [
+                {
+                    "src_id": 9,
+                    "dst_id": 1,
+                    "edge_type": 3,
+                    "weight": 1.0,
+                },
+                {
+                    "src_id": 9,
+                    "dst_id": 2,
+                    "edge_type": 0,
+                    "weight": 0.5,
+                }
+            ],
+        },
+    ]
+    for el in graph:
+        json.dump(el, data)
+        data.write("\n")
+    data.flush()
+    data.close()
+
+    return data.name
+
+def graph_with_inverse_edge_type_order_tsv(folder):
+    data = open(os.path.join(folder, "graph.tsv"), "w+")
+    data.write("9\t0\t1\tf:0 1;f:-0.01 -0.02\t1,3,1.0|2,0,0.5\n")
+    data.flush()
+    data.close()
+    return data.name
+
+@pytest.fixture(scope="module")
+def graph_with_inverse_edge_type_order(request):
+    workdir = tempfile.TemporaryDirectory()
+    if request.param == JsonDecoder:
+        data_name = graph_with_inverse_edge_type_order_json(workdir.name)
+    elif request.param == TsvDecoder:
+        data_name = graph_with_inverse_edge_type_order_tsv(workdir.name)
+    else:
+        raise ValueError("Unsupported format.")
+
+    yield data_name, request.param
+    workdir.cleanup()
+
+@pytest.mark.parametrize("graph_with_inverse_edge_type_order", param, indirect=True)
+def test_edge_index_inverted_types(graph_with_inverse_edge_type_order):
+    output = tempfile.TemporaryDirectory()
+    data_name, decoder = graph_with_inverse_edge_type_order
+    convert.MultiWorkersConverter(
+        graph_path=data_name,
+        partition_count=1,
+        output_dir=output.name,
+        decoder=decoder(),
+    ).convert()
+    with open("{}/edge_{}_{}.index".format(output.name, 0, 0), "rb") as ei:
+        expected_size = 3 * 24  # 2 edges + last line as final close
+        result = ei.read(expected_size + 100)
+        assert len(result) == expected_size
+        assert result[0:8] == (2).to_bytes(8, byteorder=sys.byteorder)
+        assert result[8:16] == (0).to_bytes(8, byteorder=sys.byteorder)
+        assert result[16:20] == (0).to_bytes(4, byteorder=sys.byteorder)
+        assert result[20:24] == struct.pack("f", 0.5)
+
+        assert result[24:32] == (1).to_bytes(8, byteorder=sys.byteorder)
+        assert result[32:40] == (0).to_bytes(8, byteorder=sys.byteorder)
+        assert result[40:44] == (3).to_bytes(4, byteorder=sys.byteorder)
+        assert result[44:48] == struct.pack("f", 1.0)
+
+        assert result[48:56] == (0).to_bytes(8, byteorder=sys.byteorder)
+        assert result[56:64] == (0).to_bytes(8, byteorder=sys.byteorder)
+        assert result[64:68] == (0).to_bytes(4, byteorder=sys.byteorder)
+        assert result[68:72] == struct.pack("f", -1)
 
 if __name__ == "__main__":
     sys.exit(


### PR DESCRIPTION
- [x] Forked repo is synced with upstream -> github shows no code delta outside of the desired.
    https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork
- [x] Tests are passing? https://github.com/microsoft/DeepGNN/blob/main/CONTRIBUTING.md#run-tests
- [x] Documentation is added or updated to reflect new code in the same format as the rest of the repo.
- [x] PR is labeled using the label menu on the right side.

Previous Behavior
----------------
Edge index was not sorted by type for each source node. This results in under sampling of neighbors with types smaller than a previous type in index and missing edge features.

New Behavior
----------------
Edges are sorted by type and sampling/extraction will be corrected.