### PR TITLE
Fix hdfs edge features filename.

### DIFF
--- a/src/cc/lib/graph/partition.cc
+++ b/src/cc/lib/graph/partition.cc
@@ -293,7 +293,7 @@ void Partition::ReadEdgeFeaturesData(std::filesystem::path path, std::string suf
 {
     if (is_hdfs_path(path))
     {
-        auto full_path = path / ("edge_features" + suffix + ".data");
+        auto full_path = path / ("edge_features_" + suffix + ".data");
         m_edge_features = std::make_shared<HDFSStorage<uint8_t>>(full_path.c_str(), m_metadata.m_config_path,
                                                                  std::move(suffix), &open_edge_features_data);
     }


### PR DESCRIPTION
- [x] Forked repo is synced with upstream -> github shows no code delta outside of the desired.
    https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork
- [x] Tests are passing? https://github.com/microsoft/DeepGNN/blob/main/CONTRIBUTING.md#run-tests
- [x] Documentation is added or updated to reflect new code in the same format as the rest of the repo.
- [x] PR is labeled using the label menu on the right side.

New Behavior
----------------
HFDS should use "edge_features_" not "edge_features".