### PR TITLE
Introduce version for binary data.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Adds neighbor count method to graph.
 
+### Fixed
 - Return empty indices and values for missing sparse features.
 
 ## [0.1.54] - 2022-08-04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Breaking. Added version checks for binary data. Requires to convert graph data or add v1 at the top of meta files.
+
 ## [0.1.55] - 2022-08-26
 
 ### Added
@@ -13,7 +16,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Adds neighbor count method to graph.
 
-### Fixed
 - Return empty indices and values for missing sparse features.
 
 ## [0.1.54] - 2022-08-04

--- a/docs/advanced/sql_shard.rst
+++ b/docs/advanced/sql_shard.rst
@@ -63,6 +63,7 @@ In this example we'll use sqlite3 module to connect to a database and fetch feat
     ...    def GetMetadata(self, request, context):
     ...        """Global information about graph. Needed to initialize client."""
     ...        return service_pb2.MetadataReply(
+    ...            version=1,
     ...            nodes=1,
     ...            edges=0,
     ...            node_types=1,

--- a/docs/graph_engine/data_spec.rst
+++ b/docs/graph_engine/data_spec.rst
@@ -119,6 +119,7 @@ Graph `meta.txt` is as follows with all pieces of text replaced by integers,
 
 .. code-block:: text
 
+	version
 	node_count
 	edge_count
 	node_type_count

--- a/docs/graph_engine/data_spec.rst
+++ b/docs/graph_engine/data_spec.rst
@@ -119,7 +119,7 @@ Graph `meta.txt` is as follows with all pieces of text replaced by integers,
 
 .. code-block:: text
 
-	version
+	binary_data_version
 	node_count
 	edge_count
 	node_type_count

--- a/docs/graph_engine/spark_converter.rst
+++ b/docs/graph_engine/spark_converter.rst
@@ -65,6 +65,7 @@ increment relevant counters for each node and edge for each processed node. When
 .. code-block:: python
 
     >>> import itertools
+    >>> from deepgnn.graph_engine.snark.meta import VERSION
     >>> class PartitionMeta:
     ...     def __init__(self, partition_id:int):
     ...         self.node_count = 0
@@ -92,7 +93,8 @@ increment relevant counters for each node and edge for each processed node. When
     ...     def close(self, binary_dir: str):
     ...         with open(os.path.join(binary_dir, "meta_%d.txt" % self.partition_ids[0]), "w+") as f:
     ...             contents = "\n".join(list(map(str, itertools.chain(
-    ...                 [self.node_count,
+    ...                 [VERSION,
+    ...                 self.node_count,
     ...                 self.edge_count,
     ...                 self.node_type_count,
     ...                 self.edge_type_count,

--- a/docs/graph_engine/spark_converter.rst
+++ b/docs/graph_engine/spark_converter.rst
@@ -65,7 +65,7 @@ increment relevant counters for each node and edge for each processed node. When
 .. code-block:: python
 
     >>> import itertools
-    >>> from deepgnn.graph_engine.snark.meta import VERSION
+    >>> from deepgnn.graph_engine.snark.meta import BINARY_DATA_VERSION
     >>> class PartitionMeta:
     ...     def __init__(self, partition_id:int):
     ...         self.node_count = 0
@@ -93,7 +93,7 @@ increment relevant counters for each node and edge for each processed node. When
     ...     def close(self, binary_dir: str):
     ...         with open(os.path.join(binary_dir, "meta_%d.txt" % self.partition_ids[0]), "w+") as f:
     ...             contents = "\n".join(list(map(str, itertools.chain(
-    ...                 [VERSION,
+    ...                 [BINARY_DATA_VERSION,
     ...                 self.node_count,
     ...                 self.edge_count,
     ...                 self.node_type_count,

--- a/src/cc/lib/benchmark/grpc_benchmark.cc
+++ b/src/cc/lib/benchmark/grpc_benchmark.cc
@@ -165,6 +165,7 @@ void BM_DISTRIBUTED_SAMPLER_MULTIPLE_SERVERS(benchmark::State &state)
         }
         {
             std::ofstream meta(path / "meta.txt");
+            meta << "v" << snark::MINIMUM_SUPPORTED_VERSION << "\n";
             meta << num_nodes_in_server << "\n";
             meta << 0 << "\n";                   // num edges
             meta << 1 << "\n";                   // node_types_count

--- a/src/cc/lib/benchmark/neighbor_sampler_benchmark.cc
+++ b/src/cc/lib/benchmark/neighbor_sampler_benchmark.cc
@@ -134,6 +134,7 @@ snark::Graph create_graph(size_t num_types, size_t num_nodes_per_partition, size
 
     {
         std::ofstream meta(path / "meta.txt");
+        meta << "v" << snark::MINIMUM_SUPPORTED_VERSION << "\n";
         meta << num_nodes << "\n";
         meta << num_edges << "\n";
 

--- a/src/cc/lib/distributed/client.cc
+++ b/src/cc/lib/distributed/client.cc
@@ -1113,6 +1113,7 @@ void GRPCClient::WriteMetadata(std::filesystem::path path)
 
     call->callback = [&reply, &path]() {
         Metadata meta;
+        meta.m_version = reply.version();
         meta.m_node_count = reply.nodes();
         meta.m_edge_count = reply.edges();
         meta.m_node_type_count = reply.node_types();

--- a/src/cc/lib/distributed/graph_engine.cc
+++ b/src/cc/lib/distributed/graph_engine.cc
@@ -511,6 +511,7 @@ grpc::Status GraphEngineServiceImpl::UniformSampleNeighbors(::grpc::ServerContex
 grpc::Status GraphEngineServiceImpl::GetMetadata(::grpc::ServerContext *context, const snark::EmptyMessage *request,
                                                  snark::MetadataReply *response)
 {
+    response->set_version(m_metadata.m_version);
     response->set_nodes(m_metadata.m_node_count);
     response->set_edges(m_metadata.m_edge_count);
     response->set_node_types(m_metadata.m_node_type_count);

--- a/src/cc/lib/distributed/service.proto
+++ b/src/cc/lib/distributed/service.proto
@@ -58,6 +58,7 @@ message MetadataReply {
   repeated float edge_partition_weights = 9;
   repeated uint64 node_count_per_type = 10;
   repeated uint64 edge_count_per_type = 11;
+  uint64 version = 12;
 }
 
 message CreateSamplerReply {

--- a/src/cc/lib/graph/metadata.h
+++ b/src/cc/lib/graph/metadata.h
@@ -10,6 +10,9 @@
 
 namespace snark
 {
+
+const size_t MINIMUM_SUPPORTED_VERSION = 1;
+
 struct Metadata
 {
     Metadata() = default;
@@ -17,6 +20,7 @@ struct Metadata
     void Write(std::filesystem::path path) const;
 
     // Graph information.
+    size_t m_version;
     size_t m_node_count;
     size_t m_edge_count;
     size_t m_edge_type_count;

--- a/src/cc/tests/distributed_test.cc
+++ b/src/cc/tests/distributed_test.cc
@@ -1052,6 +1052,7 @@ struct SamplerData
             }
             {
                 auto meta = fopen((path / "meta.txt").string().c_str(), "w+");
+                fprintf(meta, "v%ld\n", snark::MINIMUM_SUPPORTED_VERSION);
                 fprintf(meta, "%ld\n", num_nodes_in_server);
                 fprintf(meta, "%ld\n", num_edge_records_in_server / 2);
                 fprintf(meta, "1\n");                        // node_types_count

--- a/src/cc/tests/mocks.cc
+++ b/src/cc/tests/mocks.cc
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #include "src/cc/tests/mocks.h"
+#include "src/cc/lib/graph/metadata.h"
 
 #include <fstream>
 
@@ -94,6 +95,7 @@ snark::Partition convert(std::filesystem::path path, std::string suffix, MemoryG
     }
     {
         std::ofstream meta(path / "meta.txt");
+        meta << "v" << snark::MINIMUM_SUPPORTED_VERSION << "\n";
         meta << counter << "\n";
         meta << nb_index.size() << "\n";
 

--- a/src/python/deepgnn/graph_engine/backends/snark/client.py
+++ b/src/python/deepgnn/graph_engine/backends/snark/client.py
@@ -178,7 +178,7 @@ class SnarkDistributedBackend(GraphEngineBackend):
                 # Use a simple heuristic: number of original partitions, but cap it at 4
                 # to avoid extreme cases. Partition count is written on 7th line.
                 lines = meta.readlines()
-                options.num_ge = min(int(lines[6]), 4)
+                options.num_ge = min(int(lines[7]), 4)
 
         # Use explicitly set index if it was provided
         if options.server_idx is not None:

--- a/src/python/deepgnn/graph_engine/snark/convert.py
+++ b/src/python/deepgnn/graph_engine/snark/convert.py
@@ -15,6 +15,7 @@ from deepgnn.graph_engine.snark.dispatcher import (
     PipeDispatcher,
     Dispatcher,
 )
+from deepgnn.graph_engine.snark.meta import VERSION
 
 
 class MultiWorkersConverter:
@@ -129,6 +130,8 @@ class MultiWorkersConverter:
         ) as mtxt:
             mtxt.writelines(
                 [
+                    str(VERSION),
+                    "\n",
                     str(d.prop("node_count")),
                     "\n",
                     str(d.prop("edge_count")),

--- a/src/python/deepgnn/graph_engine/snark/convert.py
+++ b/src/python/deepgnn/graph_engine/snark/convert.py
@@ -15,7 +15,7 @@ from deepgnn.graph_engine.snark.dispatcher import (
     PipeDispatcher,
     Dispatcher,
 )
-from deepgnn.graph_engine.snark.meta import VERSION
+from deepgnn.graph_engine.snark.meta import BINARY_DATA_VERSION
 
 
 class MultiWorkersConverter:
@@ -130,7 +130,7 @@ class MultiWorkersConverter:
         ) as mtxt:
             mtxt.writelines(
                 [
-                    str(VERSION),
+                    str(BINARY_DATA_VERSION),
                     "\n",
                     str(d.prop("node_count")),
                     "\n",

--- a/src/python/deepgnn/graph_engine/snark/distributed.py
+++ b/src/python/deepgnn/graph_engine/snark/distributed.py
@@ -46,7 +46,7 @@ class Server:
         with open(os.path.join(data_path, "meta.txt"), "r") as meta:
             # TODO(alsamylk): expose graph metadata reader in snark.
             # Based on snark.client._read_meta() method
-            skip_lines = 6
+            skip_lines = 7
             for _ in range(skip_lines):
                 meta.readline()
             partition_count = int(meta.readline())

--- a/src/python/deepgnn/graph_engine/snark/meta.py
+++ b/src/python/deepgnn/graph_engine/snark/meta.py
@@ -10,7 +10,7 @@ from deepgnn.graph_engine.snark._lib import _get_c_lib
 import platform
 
 """Version of binary files produced by converters to communicate breaking changes requiring regeneration of binary files."""
-VERSION = "v1"
+BINARY_DATA_VERSION = "v1"
 
 
 # Use custom separators in case we want to download data from remote filesystems.

--- a/src/python/deepgnn/graph_engine/snark/meta.py
+++ b/src/python/deepgnn/graph_engine/snark/meta.py
@@ -9,6 +9,9 @@ from ctypes import c_char_p
 from deepgnn.graph_engine.snark._lib import _get_c_lib
 import platform
 
+"""Version of binary files produced by converters to communicate breaking changes requiring regeneration of binary files."""
+VERSION = "v1"
+
 
 # Use custom separators in case we want to download data from remote filesystems.
 def _get_meta_path(path: str, sep=os.path.sep) -> str:
@@ -140,6 +143,7 @@ class Meta:
 
         meta = open(_get_meta_path(path), "r")  # type: ignore
 
+        self.version = str(meta.readline().strip())
         self.node_count = int(meta.readline())
         self.edge_count = int(meta.readline())
         self.node_type_count = int(meta.readline())

--- a/src/python/deepgnn/graph_engine/snark/tests/convert_test.py
+++ b/src/python/deepgnn/graph_engine/snark/tests/convert_test.py
@@ -15,7 +15,7 @@ import numpy.testing as npt
 import deepgnn.graph_engine.snark.convert as convert
 from deepgnn.graph_engine.snark.decoders import JsonDecoder, TsvDecoder
 from deepgnn.graph_engine.snark.dispatcher import QueueDispatcher
-from deepgnn.graph_engine.snark.meta import VERSION
+from deepgnn.graph_engine.snark.meta import BINARY_DATA_VERSION
 
 
 def triangle_graph_json(folder):
@@ -300,7 +300,7 @@ def test_sanity_metadata(triangle_graph):
         result = ni.readlines()
 
         assert len(result) == 19
-        assert result[0].strip() == VERSION
+        assert result[0].strip() == BINARY_DATA_VERSION
         assert int(result[1]) == 3
         assert int(result[2]) == 3
         assert int(result[3]) == 3

--- a/src/python/deepgnn/graph_engine/snark/tests/convert_test.py
+++ b/src/python/deepgnn/graph_engine/snark/tests/convert_test.py
@@ -15,6 +15,7 @@ import numpy.testing as npt
 import deepgnn.graph_engine.snark.convert as convert
 from deepgnn.graph_engine.snark.decoders import JsonDecoder, TsvDecoder
 from deepgnn.graph_engine.snark.dispatcher import QueueDispatcher
+from deepgnn.graph_engine.snark.meta import VERSION
 
 
 def triangle_graph_json(folder):
@@ -298,29 +299,30 @@ def test_sanity_metadata(triangle_graph):
     with open("{}/meta.txt".format(output.name), "r") as ni:
         result = ni.readlines()
 
-        assert len(result) == 18
-        assert int(result[0]) == 3
+        assert len(result) == 19
+        assert result[0].strip() == VERSION
         assert int(result[1]) == 3
         assert int(result[2]) == 3
-        assert int(result[3]) == 2
+        assert int(result[3]) == 3
         assert int(result[4]) == 2
         assert int(result[5]) == 2
+        assert int(result[6]) == 2
 
         # partition information
-        assert int(result[6]) == 1
-        assert int(result[7]) == 0
-        assert float(result[8]) == 1
+        assert int(result[7]) == 1
+        assert int(result[8]) == 0
         assert float(result[9]) == 1
         assert float(result[10]) == 1
-        assert float(result[11]) == 0.5
-        assert float(result[12]) == 1.7
+        assert float(result[11]) == 1
+        assert float(result[12]) == 0.5
+        assert float(result[13]) == 1.7
 
         # type counts
-        assert int(result[13]) == 1
         assert int(result[14]) == 1
         assert int(result[15]) == 1
         assert int(result[16]) == 1
-        assert int(result[17]) == 2
+        assert int(result[17]) == 1
+        assert int(result[18]) == 2
 
 
 @pytest.mark.parametrize("triangle_graph", param, indirect=True)


### PR DESCRIPTION
- [x] Forked repo is synced with upstream -> github shows no code delta outside of the desired.
    https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork
- [x] Tests are passing? https://github.com/microsoft/DeepGNN/blob/main/CONTRIBUTING.md#run-tests
- [x] Changelog and documentation updated.
- [x] PR is labeled using the label menu on the right side.

Previous Behavior
----------------
* We have to communicate breaking changes in binaries directly.

New Behavior
----------------
* Metadata files now contain a version of the converter binary files were generated with. GE reads this metadata and verifies it can work with these binaries.