### PR TITLE
Don't skip empty sparse features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.55] - 2022-08-26
+
 ### Added
 - Support nodes and their outgoing edges on different partitions.
 
 - Adds neighbor count method to graph.
+
+### Fixed
+- Return empty indices and values for missing sparse features.
 
 ## [0.1.54] - 2022-08-04
 

--- a/src/python/deepgnn/graph_engine/snark/client.py
+++ b/src/python/deepgnn/graph_engine/snark/client.py
@@ -87,7 +87,9 @@ class _SparseFeatureCallback:
         self.dimensions = np.copy(np.ctypeslib.as_array(dimensions, [self.feature_len]))
         for i in range(self.feature_len):
             if indices_len[i] == 0:
-                return
+                self.indices.append(np.empty(0, dtype=np.int64))
+                self.values.append(np.empty(0, dtype=self.dtype))
+                continue
 
             # Increment original feature dimensions by 1, because we use node offset as
             # the first dimension and it is not present in binary format

--- a/src/python/deepgnn/graph_engine/snark/tests/sparse_features_test.py
+++ b/src/python/deepgnn/graph_engine/snark/tests/sparse_features_test.py
@@ -175,8 +175,8 @@ def test_multiple_edges_sparse_features(graph_with_sparse_features):
     )
 
     npt.assert_equal(dimensions, [0])
-    assert len(indices) == 0
-    assert len(values) == 0
+    assert len(indices) == 1
+    assert len(values) == 1
 
 
 @pytest.mark.parametrize("graph_with_sparse_features", [1, 2], indirect=True)
@@ -246,8 +246,8 @@ def test_distributed_node_with_empty_sparse_features(
         dtype=np.float32,
     )
 
-    assert len(indices) == 0
-    assert len(values) == 0
+    assert len(indices) == 1
+    assert len(values) == 1
     assert dimensions == [0]
 
 
@@ -264,8 +264,8 @@ def test_distributed_node_with_wrong_id_sparse_features(
         dtype=np.float32,
     )
 
-    assert len(indices) == 0
-    assert len(values) == 0
+    assert len(indices) == 2
+    assert len(values) == 2
     npt.assert_equal(dimensions, [0, 0])
 
 
@@ -300,15 +300,16 @@ def test_distributed_multiple_edges_multiple_sparse_features(
         edge_src=np.array([9, 5, 0], dtype=np.int64),
         edge_dst=np.array([0, 9, 5], dtype=np.int64),
         edge_tp=np.array([0, 1, 1], dtype=np.int32),
-        features=np.array([4, 1], dtype=np.int32),
+        features=np.array([4, 13, 1], dtype=np.int32),
         dtype=np.int16,
     )
 
-    npt.assert_equal(dimensions, [1, 3])
-    assert len(indices) == 2
+    npt.assert_equal(dimensions, [1, 0, 3])
+    assert len(indices) == 3
     npt.assert_equal(indices[0], [[0, 7], [0, 3], [2, 17], [2, 13]])
-    npt.assert_equal(indices[1], [[0, 12, 5, 3], [2, 18, 15, 12]])
-    npt.assert_equal(values, [[255, 16, 2, 4], [5, 1024]])
+    npt.assert_equal(indices[1], [])
+    npt.assert_equal(indices[2], [[0, 12, 5, 3], [2, 18, 15, 12]])
+    npt.assert_equal(values, [[255, 16, 2, 4], [], [5, 1024]])
 
 
 # We'll use this class for deterministic partitioning


### PR DESCRIPTION
- [x] Forked repo is synced with upstream -> github shows no code delta outside of the desired.
    https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork
- [x] Tests are passing? https://github.com/microsoft/DeepGNN/blob/main/CONTRIBUTING.md#run-tests
- [x] Changelog and documentation updated.
- [x] PR is labeled using the label menu on the right side.

Previous Behavior
----------------
* If no sparse features are present for some nodes in the request we returned early in a python callback and instead should create empty lists for indices/values and continue iteration.

New Behavior
----------------
* First dimension of indices/values lists is always equal to number of requested features.