### PR TITLE
Windows use 0 dataloader workers.

### DIFF
--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -40,7 +40,7 @@ runs:
         bazel test -c dbg //examples/tensorflow/...:* --jobs 1 --test_output=all --test_timeout 6000 --config=${{ env.BAZEL_CONFIG }} --disk_cache=~/bazel-cache
       shell: bash
       name: run python tests in examples folder
-      if: runner.os = 'Linux'
+      if: runner.os == 'Linux'
     - run: |
         bazel test -c dbg //docs:* --test_output=all --config=linux --disk_cache=~/bazel-cache
         bazel run -c dbg //docs:make_docs --config=linux

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -40,7 +40,7 @@ runs:
         bazel test -c dbg //examples/tensorflow/...:* --jobs 1 --test_output=all --test_timeout 6000 --config=${{ env.BAZEL_CONFIG }} --disk_cache=~/bazel-cache
       shell: bash
       name: run python tests in examples folder
-      if: runner.os != 'macOS'
+      if: runner.os = 'Linux'
     - run: |
         bazel test -c dbg //docs:* --test_output=all --config=linux --disk_cache=~/bazel-cache
         bazel run -c dbg //docs:make_docs --config=linux

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -40,7 +40,6 @@ runs:
         bazel test -c dbg //examples/tensorflow/...:* --jobs 1 --test_output=all --test_timeout 6000 --config=${{ env.BAZEL_CONFIG }} --disk_cache=~/bazel-cache
       shell: bash
       name: run python tests in examples folder
-      if: runner.os == 'Linux'
     - run: |
         bazel test -c dbg //docs:* --test_output=all --config=linux --disk_cache=~/bazel-cache
         bazel run -c dbg //docs:make_docs --config=linux

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -40,6 +40,7 @@ runs:
         bazel test -c dbg //examples/tensorflow/...:* --jobs 1 --test_output=all --test_timeout 6000 --config=${{ env.BAZEL_CONFIG }} --disk_cache=~/bazel-cache
       shell: bash
       name: run python tests in examples folder
+      if: runner.os != 'macOS'
     - run: |
         bazel test -c dbg //docs:* --test_output=all --config=linux --disk_cache=~/bazel-cache
         bazel run -c dbg //docs:make_docs --config=linux

--- a/examples/pytorch/hetgnn/BUILD
+++ b/examples/pytorch/hetgnn/BUILD
@@ -60,7 +60,6 @@ py_test(
     srcs_version = "PY3",
     deps = [
         ":example_torch_hetgnn",
-        requirement("horovod"),
         requirement("fsspec"),
         requirement("numpy"),
         requirement("pytest"),

--- a/src/python/deepgnn/pytorch/training/factory.py
+++ b/src/python/deepgnn/pytorch/training/factory.py
@@ -4,6 +4,7 @@
 """Functions to start distributed training."""
 
 import argparse
+import platform
 import torch
 from typing import Optional, Callable, List
 from deepgnn import TrainerType
@@ -117,7 +118,7 @@ def run_dist(
 
     num_workers = (
         0
-        if issubclass(dataset.sampler_class, (GENodeSampler, GEEdgeSampler))
+        if issubclass(dataset.sampler_class, (GENodeSampler, GEEdgeSampler)) or platform.system() == "Windows"
         else args.data_parallel_num
     )
 

--- a/src/python/deepgnn/pytorch/training/factory.py
+++ b/src/python/deepgnn/pytorch/training/factory.py
@@ -118,7 +118,8 @@ def run_dist(
 
     num_workers = (
         0
-        if issubclass(dataset.sampler_class, (GENodeSampler, GEEdgeSampler)) or platform.system() == "Windows"
+        if issubclass(dataset.sampler_class, (GENodeSampler, GEEdgeSampler))
+        or platform.system() == "Windows"
         else args.data_parallel_num
     )
 


### PR DESCRIPTION
- [ x] Forked repo is synced with upstream -> github shows no code delta outside of the desired.
    https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork
- [x] Tests are passing? https://github.com/microsoft/DeepGNN/blob/main/CONTRIBUTING.md#run-tests
- [x] Changelog and documentation updated.
- [x] PR is labeled using the label menu on the right side.

Previous Behavior
----------------
#83 

Error with run.sh scripts using FileNodeSampler on windows caused by non-zero dataloader workers.

New Behavior
----------------
When using windows, 0 dataloader workers will be used by default to avoid fork.