### PR TITLE
Use ubuntu-22.04 and gcc-11

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -3,7 +3,7 @@
 
 # We want to have a dynamic library without any dependencies,
 # that's why we statically link standard libs.
-build:linux --repo_env=CC=gcc-10
+build:linux --repo_env=CC=gcc-11
 build:linux --action_env=BAZEL_LINKLIBS=-l%:libstdc++.a
 build:linux --action_env=BAZEL_LINKOPTS=-static-libgcc:-lm:-pthread
 build:linux --action_env=SETUPTOOLS_USE_DISTUTILS="false"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.8", "3.9"]
-        os: ["ubuntu-latest", "macos-11", "windows-2019"]
+        os: ["ubuntu-22.04", "macos-11", "windows-2019"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
@@ -29,7 +29,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.8", "3.9"]
-        os: ["ubuntu-latest", "macos-11", "windows-2019"]
+        os: ["ubuntu-22.04", "macos-11", "windows-2019"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
@@ -43,7 +43,7 @@ jobs:
           disk_cache: test-${{ matrix.os }}-${{ matrix.python-version }}
   benchmarks:
     needs: tests
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-22.04"
     steps:
       - uses: actions/checkout@v3
       - name: Run benchmarks
@@ -51,7 +51,7 @@ jobs:
         with:
           disk_cache: benchmark-${{ matrix.os }}
   wheel:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: tests
     steps:
       - uses: actions/checkout@v3
@@ -78,7 +78,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.8", "3.9"]
-        os: ["ubuntu-latest", "ubuntu-18.04"]
+        os: ["ubuntu-22.04", "ubuntu-20.04"]
     runs-on: ${{ matrix.os }}
     env:
       HOROVOD_WITH_GLOO: 1
@@ -122,7 +122,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.8", "3.9"]
-        os: ["ubuntu-latest", "ubuntu-18.04"]
+        os: ["ubuntu-22.04", "ubuntu-20.04"]
     runs-on: ${{ matrix.os }}
     env:
       HOROVOD_WITH_GLOO: 1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.8", "3.9"]
-        os: ["ubuntu-latest", "macos-11", "windows-2019"]
+        os: ["ubuntu-22.04", "macos-11", "windows-2019"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.8", "3.9"]
-        os: ["ubuntu-latest", "macos-11", "windows-2019"]
+        os: ["ubuntu-22.04", "macos-11", "windows-2019"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ["ubuntu-latest", "macos-11", "windows-2019"]
+        os: ["ubuntu-22.04", "macos-11", "windows-2019"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python 3.8


### PR DESCRIPTION
- [x] Forked repo is synced with upstream -> github shows no code delta outside of the desired.
    https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork
- [x] Tests are passing? https://github.com/microsoft/DeepGNN/blob/main/CONTRIBUTING.md#run-tests
- [x] Changelog and documentation updated.
- [x] PR is labeled using the label menu on the right side.

Previous Behavior
-------------------

Use ubuntu 20.04, which is not latest despite CI flags.

New Behavior
----------------
Test on ubuntu 20.04 and 22.04 and use gcc-11 to compile C++ code. Drop testing against ubuntu 18.04, since it will not be supported after April 2023.
Differences between ubuntu-latest and ubuntu-22.04: https://github.com/actions/runner-images/issues/5490.
