### PR TITLE
Add debug mode to MultiWorkersConverter.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Breaking. Added version checks for binary data. Requires to convert graph data or add v1 at the top of meta files.
 
+- Add Debug mode to MultiWorkersConverter, using worker_count=0 will now show error messages.
+
+### Changed
+- Rename function deepgnn.graph_engine.data.to_json_node -> deepgnn.graph_engine.data.to_edge_list_node and update functionality accordingly.
+
 ## [0.1.55] - 2022-08-26
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Breaking. Added version checks for binary data. Requires to convert graph data or add v1 at the top of meta files.
 
-- Add Debug mode to MultiWorkersConverter, using worker_count=0 will now show error messages.
-
-### Changed
-- Rename function deepgnn.graph_engine.data.to_json_node -> deepgnn.graph_engine.data.to_edge_list_node and update functionality accordingly.
+- Add debug mode to MultiWorkersConverter, using worker_count=0 will now disable multiprocessing and show error messages.
 
 ## [0.1.55] - 2022-08-26
 

--- a/src/python/deepgnn/graph_engine/snark/convert.py
+++ b/src/python/deepgnn/graph_engine/snark/convert.py
@@ -105,8 +105,6 @@ class MultiWorkersConverter:
             f"worker {self.worker_index} try to generate partition: {self.partition_offset} - {self.partition_count + self.partition_offset}"
         )
 
-<<<<<<< Updated upstream
-        d = self.dispatcher
         if self.file_iterator is None:
             self.file_iterator = TextFileIterator(
                 filename=self.graph_path,
@@ -120,26 +118,9 @@ class MultiWorkersConverter:
                 num_workers=self.worker_count,
             )
 
-        for _, data in enumerate(self.file_iterator):
-            for line in data:
-                d.dispatch(line)
-
-        d.join()
-=======
-        dataset = TextFileIterator(
-            filename=self.graph_path,
-            store_name=None,
-            batch_size=self.record_per_step,
-            epochs=1,
-            read_block_in_M=self.read_block_in_M,
-            buffer_queue_size=self.buffer_queue_size,
-            thread_count=self.thread_count,
-            worker_index=self.worker_index,
-            num_workers=max(1, self.worker_count),
-        )
         if self.worker_count >= 1:
             d = self.dispatcher
-            for _, data in enumerate(dataset):
+            for _, data in enumerate(self.file_iterator):
                 for line in data:
                     d.dispatch(line)
 
@@ -149,13 +130,12 @@ class MultiWorkersConverter:
             if isinstance(self.decoder, type):
                 self.decoder = self.decoder()
             writer = BinaryWriter(self.output_dir, 0)
-            for _, data in enumerate(dataset):
+            for _, data in enumerate(self.file_iterator):
                 for line in data:
                     writer.add(self.decoder.decode(line))
             writer.close()
             d = writer
 
->>>>>>> Stashed changes
 
         fs, _ = get_fs(self.output_dir)
         with fs.open(

--- a/src/python/deepgnn/graph_engine/snark/converter/writers.py
+++ b/src/python/deepgnn/graph_engine/snark/converter/writers.py
@@ -120,13 +120,31 @@ class BinaryWriter:
         self.edge_writer.close()
         self.node_alias.close()
         self.edge_alias.close()
-        self.partitions = [self]
+
+        # For MultiWorkersConverter with 0 workers
         self.id = 0
+        self.partitions = [self]
 
-    def prop(self, key):
-        return getattr(self, key)
+    def prop(self, name: str) -> typing.Any:
+        """Properties relevant for conversion.
 
-    def __getitem__(self, key):
+        Args:
+            name (str): property name.
+
+        Returns:
+            typing.Any: property value.
+        """
+        return getattr(self, name.lower())
+
+    def __getitem__(self, key) -> typing.Any:
+        """Properties relevant for conversion.
+
+        Args:
+            name (str): property name.
+
+        Returns:
+            typing.Any: property value.
+        """
         return getattr(self, key)
 
 

--- a/src/python/deepgnn/graph_engine/snark/converter/writers.py
+++ b/src/python/deepgnn/graph_engine/snark/converter/writers.py
@@ -120,6 +120,15 @@ class BinaryWriter:
         self.edge_writer.close()
         self.node_alias.close()
         self.edge_alias.close()
+        self.partitions = [self]
+        self.id = 0
+
+    def prop(self, key):
+        return getattr(self, key)
+
+    def __getitem__(self, key):
+        return getattr(self, key)
+
 
 
 class NodeWriter:

--- a/src/python/deepgnn/graph_engine/snark/tests/convert_test.py
+++ b/src/python/deepgnn/graph_engine/snark/tests/convert_test.py
@@ -115,6 +115,44 @@ param = [JsonDecoder, TsvDecoder]
 
 
 @pytest.mark.parametrize("triangle_graph", param, indirect=True)
+def test_converter_0_workers(triangle_graph):
+    output = tempfile.TemporaryDirectory()
+    data_name, decoder = triangle_graph
+    convert.MultiWorkersConverter(
+        graph_path=data_name,
+        partition_count=1,
+        output_dir=output.name,
+        decoder=decoder(),
+        worker_count=0,
+    ).convert()
+
+    with open("{}/node_{}_{}.map".format(output.name, 0, 0), "rb") as nm:
+        expected_size = 3 * (2 * 8 + 4)
+        result = nm.read(expected_size + 8)
+        assert len(result) == expected_size
+        assert result[0:8] == (9).to_bytes(8, byteorder=sys.byteorder)
+        assert result[8:16] == (0).to_bytes(8, byteorder=sys.byteorder)
+        assert result[16:20] == (0).to_bytes(4, byteorder=sys.byteorder)
+        assert result[20:28] == (0).to_bytes(8, byteorder=sys.byteorder)
+        assert result[28:36] == (1).to_bytes(8, byteorder=sys.byteorder)
+        assert result[36:40] == (1).to_bytes(4, byteorder=sys.byteorder)
+        assert result[40:48] == (5).to_bytes(8, byteorder=sys.byteorder)
+        assert result[48:56] == (2).to_bytes(8, byteorder=sys.byteorder)
+        assert result[56:60] == (2).to_bytes(4, byteorder=sys.byteorder)
+
+    with pytest.raises(ValueError):
+        output = tempfile.TemporaryDirectory()
+        data_name, decoder = triangle_graph
+        convert.MultiWorkersConverter(
+            graph_path=data_name,
+            partition_count=1,
+            output_dir=output.name,
+            decoder=JsonDecoder() if isinstance(decoder(), EdgeListDecoder) else EdgeListDecoder(),
+            worker_count=0,
+        ).convert()
+
+
+@pytest.mark.parametrize("triangle_graph", param, indirect=True)
 def test_sanity_node_map(triangle_graph):
     output = tempfile.TemporaryDirectory()
     data_name, decoder = triangle_graph


### PR DESCRIPTION
- [x] Forked repo is synced with upstream -> github shows no code delta outside of the desired.
    https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork
- [x] Tests are passing? https://github.com/microsoft/DeepGNN/blob/main/CONTRIBUTING.md#run-tests
- [x] Changelog and documentation updated.
- [x] PR is labeled using the label menu on the right side.

Previous Behavior
----------------
* Multiprocessing in MultiWorkersConverter crashes instead of showing error messages, so it is very hard to debug EdgeList and custom decoders.

New Behavior
----------------
* Add debug mode to MultiWorkersConverter, using worker_count=0 will now disable multiprocessing and show error messages.