### PR TITLE
Fix torch dataset 1.10.2 type issue.

### DIFF
--- a/src/python/deepgnn/graph_engine/graph_dataset.py
+++ b/src/python/deepgnn/graph_engine/graph_dataset.py
@@ -4,7 +4,7 @@
 
 from enum import Enum
 from inspect import signature
-from typing import Callable, Union
+from typing import Callable, Iterator
 from deepgnn.graph_engine._base import Graph
 from deepgnn.graph_engine.backends.common import GraphEngineBackend
 from deepgnn.graph_engine.prefetch import Generator
@@ -112,7 +112,7 @@ class DeepGNNDataset:
 
         self.sampler = self.sampler_class(**sampler_args)
 
-    def __iter__(self) -> Union[Generator, _DeepGNNDatasetIterator]:
+    def __iter__(self) -> Iterator:
         """Create an iterator for graph."""
         if self.enable_prefetch:
             prefetch_size = (

--- a/src/python/deepgnn/pytorch/common/dataset.py
+++ b/src/python/deepgnn/pytorch/common/dataset.py
@@ -6,10 +6,9 @@ import torch
 from deepgnn.graph_engine import (
     DeepGNNDataset,
     GraphEngineBackend,
-    Generator,
 )
 from torch.utils.data import IterableDataset
-from typing import Callable, Union
+from typing import Callable, Iterator
 
 
 class TorchDeepGNNDataset(IterableDataset, DeepGNNDataset):
@@ -81,7 +80,7 @@ class TorchDeepGNNDataset(IterableDataset, DeepGNNDataset):
             )
         super().init_sampler()
 
-    def __iter__(self) -> Union[Generator, DeepGNNDataset._DeepGNNDatasetIterator]:
+    def __iter__(self) -> Iterator:
         """Create sampler and start iteration."""
         self._torch_init_sampler()
         return DeepGNNDataset.__iter__(self)


### PR DESCRIPTION
- [x] Forked repo is synced with upstream -> github shows no code delta outside of the desired.
    https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork
- [x] Tests are passing? https://github.com/microsoft/DeepGNN/blob/main/CONTRIBUTING.md#run-tests
- [x] Changelog and documentation updated.
- [x] PR is labeled using the label menu on the right side.

Previous Behavior
----------------
* When using torch==1.9-1.10 get error "TypeError: Expected 'Iterator' as the return annotation for `__iter__` of TorchDeepGNNDataset, but found typing.Union[deepgnn.graph_engine.prefetch.Generator, deepgnn.graph_engine.graph_dataset.DeepGNNDataset._DeepGNNDatasetIterator]"

New Behavior
----------------
* Update torch dataset type hint to be more generic == Iterator.