### PR TITLE
Update python versions and related CI actions

### DIFF
--- a/.github/actions/lint/action.yml
+++ b/.github/actions/lint/action.yml
@@ -12,7 +12,7 @@ runs:
     - run: brew install clang-format
       shell: bash
       if: runner.os == 'macOS'
-    - run: pip install wheel pre-commit==2.17.0 mypy==0.971 numpy==1.21.6 torch==1.11.0 tensorflow==2.7.2
+    - run: pip install wheel pre-commit==2.17.0 mypy==0.971 numpy==1.22.4 torch==1.11.0 tensorflow==2.8.3
       shell: bash
       name: install dependencies
     - run: pre-commit install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
   pre-commit:
     strategy:
       matrix:
-        python-version: ["3.8", "3.9"]
+        python-version: ["3.8", "3.9", "3.10"]
         os: ["ubuntu-22.04", "macos-11", "windows-2019"]
     runs-on: ${{ matrix.os }}
     steps:
@@ -28,7 +28,7 @@ jobs:
     needs: pre-commit
     strategy:
       matrix:
-        python-version: ["3.8", "3.9"]
+        python-version: ["3.10"]
         os: ["ubuntu-22.04", "macos-11", "windows-2019"]
     runs-on: ${{ matrix.os }}
     steps:
@@ -55,10 +55,10 @@ jobs:
     needs: tests
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python 3.8
+      - name: Set up Python 3.10
         uses: actions/setup-python@v3
         with:
-          python-version: "3.8"
+          python-version: "3.10"
       - name: Upload examples
         uses: actions/upload-artifact@v3
         with:
@@ -77,8 +77,8 @@ jobs:
     needs: wheel
     strategy:
       matrix:
-        python-version: ["3.8", "3.9"]
-        os: ["ubuntu-22.04", "ubuntu-20.04"]
+        python-version: ["3.10"]
+        os: ["ubuntu-22.04"]
     runs-on: ${{ matrix.os }}
     env:
       HOROVOD_WITH_GLOO: 1
@@ -121,8 +121,8 @@ jobs:
     needs: wheel
     strategy:
       matrix:
-        python-version: ["3.8", "3.9"]
-        os: ["ubuntu-22.04", "ubuntu-20.04"]
+        python-version: ["3.10"]
+        os: ["ubuntu-22.04"]
     runs-on: ${{ matrix.os }}
     env:
       HOROVOD_WITH_GLOO: 1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,7 +6,7 @@ jobs:
   pre-commit:
     strategy:
       matrix:
-        python-version: ["3.8", "3.9"]
+        python-version: ["3.8", "3.9", "3.10"]
         os: ["ubuntu-22.04", "macos-11", "windows-2019"]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     if: ${{ github.event.workflow_run == null || github.event.workflow_run.conclusion == 'success'}}
     strategy:
       matrix:
-        python-version: ["3.8", "3.9"]
+        python-version: ["3.10"]
         os: ["ubuntu-22.04", "macos-11", "windows-2019"]
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -16,10 +16,10 @@ jobs:
         os: ["ubuntu-22.04", "macos-11", "windows-2019"]
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python 3.8
+      - name: Set up Python 3.10
         uses: actions/setup-python@v3
         with:
-          python-version: "3.8"
+          python-version: "3.10"
       - name: build wheel
         uses: ./.github/actions/wheel
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,7 +89,7 @@ Install and run linters(same on all systems):
 ```sh
 pip install --upgrade pip
 pip install -r tests/requirements.txt
-pip install wheel pre-commit==2.17.0 mypy==0.971 numpy==1.21.6 torch==1.11.0 tensorflow==2.7.2
+pip install wheel pre-commit==2.17.0 mypy==0.971 numpy==1.22.4 torch==1.11.0 tensorflow==2.8.3
 pre-commit install
 pre-commit run --all-files
 ```

--- a/examples/tensorflow/requirements.txt
+++ b/examples/tensorflow/requirements.txt
@@ -2,4 +2,4 @@
 # please follow the instruction here: https://github.com/tensorflow/addons
 # to find which addon version is correct.
 horovod[tensorflow]==0.25.0;sys_platform != 'win32'
-tensorflow-addons==0.13.0
+tensorflow-addons==0.18.0

--- a/src/python/setup.py
+++ b/src/python/setup.py
@@ -43,7 +43,7 @@ def graph_engine(version: str):
             fo.write("include python/deepgnn/graph_engine/snark/%s\n" % libname)
 
     here = pathlib.Path(__file__).parent.parent.resolve()
-    long_description = (here / "../../README.md").read_text(encoding="utf-8")
+    long_description = (here / "../README.md").read_text(encoding="utf-8")
 
     setuptools.setup(
         name="deepgnn-ge",


### PR DESCRIPTION
- [x] Forked repo is synced with upstream -> github shows no code delta outside of the desired.
    https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork
- [x] Tests are passing? https://github.com/microsoft/DeepGNN/blob/main/CONTRIBUTING.md#run-tests
- [x] Changelog and documentation updated.
- [x] PR is labeled using the label menu on the right side.


Existing CI contains some redundancies:
* Tests with 3.8 and 3.9 versions of python without major benefits(and probably more drawbacks, because more runs increase a chance of a flaky error). We can use python 3.10 to run CI actions and lint code with 3.8-3.10 for compatibility. Ideally we'd use python 3.11, but tensorflow is not available with it yet.
* Use both Ubuntu 20.04 and 22.04 to run examples. This was originally introduced for checking libc version, but since we link directly to libc-2.17 and use `auditwheel`, multiple runs are not needed anymore.