### PR TITLE
Save 10 mins in lint

### DIFF
--- a/.github/actions/lint/action.yml
+++ b/.github/actions/lint/action.yml
@@ -15,6 +15,11 @@ runs:
     - run: pip install wheel pre-commit==2.17.0 mypy==0.971 numpy==1.22.4 torch==1.11.0 tensorflow==2.8.3 ray==2.2.0
       shell: bash
       name: install dependencies
+      if: runner.os != 'macOS'
+    - run: pip install wheel pre-commit==2.17.0 mypy==0.971 numpy==1.22.4 torch==1.11.0
+      shell: bash
+      name: install dependencies
+      if: runner.os == 'macOS'
     - run: pre-commit install
       shell: bash
       name: initialize pre-commit


### PR DESCRIPTION
- [x] Forked repo is synced with upstream -> github shows no code delta outside of the desired.
    https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork
- [x] Tests are passing? https://github.com/microsoft/DeepGNN/blob/main/CONTRIBUTING.md#run-tests
- [x] Changelog and documentation updated.
- [x] PR is labeled using the label menu on the right side.

New Behavior
----------------
Remove tensorflow and ray from macos pip installs for lint because they require manual building of grpcio which is very slow.