### PR TITLE
[Temporal graph][3/4] Sampling

### DIFF
--- a/src/cc/lib/distributed/client.cc
+++ b/src/cc/lib/distributed/client.cc
@@ -79,7 +79,7 @@ void ExtractFeatures(const std::vector<SparseFeatureIndex> &response_index,
         for (size_t node_index = 0; node_index < node_count; ++node_index)
         {
             auto &response_index_item = response_index[node_index * feature_count + feature_index];
-            if (replies[response_index_item.shard].indices().empty())
+            if (response_index_item.shard < 0 || replies[response_index_item.shard].indices().empty())
             {
                 continue;
             }

--- a/src/cc/lib/graph/graph.cc
+++ b/src/cc/lib/graph/graph.cc
@@ -379,7 +379,7 @@ void Graph::NeighborCount(std::span<const NodeId> input_node_ids, std::span<cons
             {
                 output_neighbors_counts[idx] += m_partitions[m_partitions_indices[index]].NeighborCount(
                     m_internal_indices[index],
-                    timestamps.empty() ? std::nullopt : std::optional<snark::Timestamp>{timestamps[index]},
+                    timestamps.empty() ? std::nullopt : std::optional<snark::Timestamp>{timestamps[idx]},
                     input_edge_types);
             }
         }
@@ -391,6 +391,7 @@ void Graph::FullNeighbor(std::span<const NodeId> input_node_ids, std::span<const
                          std::vector<Type> &output_neighbor_types, std::vector<float> &output_neighbors_weights,
                          std::span<uint64_t> output_neighbors_counts) const
 {
+    std::fill(std::begin(output_neighbors_counts), std::end(output_neighbors_counts), 0);
     for (size_t node_index = 0; node_index < input_node_ids.size(); ++node_index)
     {
         auto internal_id = m_node_map.find(input_node_ids[node_index]);
@@ -406,7 +407,7 @@ void Graph::FullNeighbor(std::span<const NodeId> input_node_ids, std::span<const
             {
                 output_neighbors_counts[node_index] += m_partitions[m_partitions_indices[index]].FullNeighbor(
                     m_internal_indices[index],
-                    timestamps.empty() ? std::nullopt : std::optional<snark::Timestamp>{timestamps[index]},
+                    timestamps.empty() ? std::nullopt : std::optional<snark::Timestamp>{timestamps[node_index]},
                     input_edge_types, output_neighbor_ids, output_neighbor_types, output_neighbors_weights);
             }
         }

--- a/src/cc/lib/graph/locator.cc
+++ b/src/cc/lib/graph/locator.cc
@@ -51,6 +51,11 @@ FILE *open_neighbor_index(std::filesystem::path path, std::string suffix)
     return open_file(path / ("neighbors_" + suffix + ".index"), "rb");
 }
 
+FILE *open_edge_timestamps(std::filesystem::path path, std::string suffix)
+{
+    return open_file(path / ("edge_" + suffix + ".timestamp"), "rb");
+}
+
 FILE *open_edge_index(std::filesystem::path path, std::string suffix)
 {
     return open_file(path / ("edge_" + suffix + ".index"), "rb");

--- a/src/cc/lib/graph/locator.h
+++ b/src/cc/lib/graph/locator.h
@@ -19,6 +19,7 @@ FILE *open_node_index(std::filesystem::path path, std::string suffix);
 FILE *open_node_features_index(std::filesystem::path path, std::string suffix);
 FILE *open_node_features_data(std::filesystem::path path, std::string suffix);
 FILE *open_neighbor_index(std::filesystem::path path, std::string suffix);
+FILE *open_edge_timestamps(std::filesystem::path path, std::string suffix);
 FILE *open_edge_index(std::filesystem::path path, std::string suffix);
 FILE *open_edge_features_index(std::filesystem::path path, std::string suffix);
 FILE *open_edge_features_data(std::filesystem::path path, std::string suffix);

--- a/src/cc/lib/graph/metadata.cc
+++ b/src/cc/lib/graph/metadata.cc
@@ -18,7 +18,7 @@ namespace snark
 {
 
 Metadata::Metadata(std::filesystem::path path, std::string config_path)
-    : m_path(path.string()), m_config_path(config_path)
+    : m_version(MINIMUM_SUPPORTED_VERSION), m_path(path.string()), m_config_path(config_path), m_watermark(-1)
 {
     if (is_hdfs_path(path))
 #ifndef SNARK_PLATFORM_LINUX

--- a/src/cc/lib/graph/partition.h
+++ b/src/cc/lib/graph/partition.h
@@ -99,6 +99,7 @@ struct Partition
     void ReadNodeFeaturesData(std::filesystem::path path, std::string suffix);
     void ReadEdgeFeaturesIndex(std::filesystem::path path, std::string suffix);
     void ReadEdgeFeaturesData(std::filesystem::path path, std::string suffix);
+    void ReadEdgeTimestamps(std::filesystem::path path, std::string suffix);
 
     void UniformSampleNeighborWithoutReplacement(int64_t seed, uint64_t internal_node_ids,
                                                  std::optional<Timestamp> timestamp,
@@ -135,6 +136,8 @@ struct Partition
     std::vector<float> m_edge_weights;
 
     std::vector<uint64_t> m_neighbors_index;
+    std::vector<std::pair<Timestamp, Timestamp>> m_edge_timestamps;
+    Timestamp m_watermark;
 
     std::vector<Type> m_node_types;
     Metadata m_metadata;

--- a/src/cc/lib/graph/types.h
+++ b/src/cc/lib/graph/types.h
@@ -3,7 +3,7 @@
 
 #ifndef SNARK_TYPES_H
 #define SNARK_TYPES_H
-#include <cstdlib>
+#include <cstdint>
 #include <utility>
 
 namespace snark

--- a/src/cc/tests/BUILD
+++ b/src/cc/tests/BUILD
@@ -30,6 +30,24 @@ cc_test(
 )
 
 cc_test(
+    name = "temporal_tests",
+    srcs = [
+        "temporal_test.cc",
+        "mocks.cc",
+        "mocks.h",
+    ],
+    copts = CXX_OPTS,
+    defines = PLATFORM_DEFINES,
+    linkopts = ["-lm"],
+    deps = [
+        ":mocks",
+        "@googletest//:gtest_main",
+        "//src/cc/lib/distributed:grpc",
+        "//src/cc/lib/graph",
+    ],
+)
+
+cc_test(
     name = "distributed_tests",
     srcs = [
         "distributed_test.cc",

--- a/src/cc/tests/distributed_test.cc
+++ b/src/cc/tests/distributed_test.cc
@@ -192,8 +192,8 @@ TEST(DistributedTest, NodeSparseFeaturesMultipleServers)
             std::shared_ptr<snark::GraphSamplerServiceImpl>{}, "localhost:0", "", "", ""));
         channels.emplace_back(servers.back()->InProcessChannel());
     }
-    snark::GRPCClient c(channels, 1, 1);
 
+    snark::GRPCClient c(channels, 1, 1);
     std::vector<snark::NodeId> input_nodes = {2, 5, 0, 1};
     std::vector<snark::FeatureId> features = {1, 0};
     std::vector<std::vector<uint8_t>> values(features.size());

--- a/src/cc/tests/graph_test.cc
+++ b/src/cc/tests/graph_test.cc
@@ -339,7 +339,8 @@ TEST_P(StorageTypeGraphTest, NodeTypesMultipleNodes)
     TestGraph::MemoryGraph m;
     m.m_nodes.push_back(TestGraph::Node{.m_id = 0, .m_type = 0, .m_weight = 1.0f});
     m.m_nodes.push_back(TestGraph::Node{.m_id = 1, .m_type = 2, .m_weight = 1.0f});
-    auto path = std::filesystem::temp_directory_path();
+    auto path = std::filesystem::path(::testing::UnitTest::GetInstance()->current_test_info()->name());
+    assert(std::filesystem::create_directories(path));
     TestGraph::convert(path, "0_0", std::move(m), 3);
     snark::Metadata metadata(path.string());
     snark::Graph g(std::move(metadata), {path.string()}, std::vector<uint32_t>{0}, GetParam());
@@ -357,7 +358,8 @@ TEST_P(StorageTypeGraphTest, NodeFeaturesMultipleNodesSingleFeature)
     std::vector<std::vector<float>> f2 = {std::vector<float>{5.0f, 6.0f, 7.0f}};
     m.m_nodes.push_back(TestGraph::Node{.m_id = 0, .m_type = 0, .m_weight = 1.0f, .m_float_features = f1});
     m.m_nodes.push_back(TestGraph::Node{.m_id = 1, .m_type = 1, .m_weight = 1.0f, .m_float_features = f2});
-    auto path = std::filesystem::temp_directory_path();
+    auto path = std::filesystem::path(::testing::UnitTest::GetInstance()->current_test_info()->name());
+    assert(std::filesystem::create_directories(path));
     TestGraph::convert(path, "0_0", std::move(m), 2);
     snark::Metadata metadata(path.string());
     snark::Graph g(std::move(metadata), {path.string()}, std::vector<uint32_t>{0}, GetParam());
@@ -375,7 +377,8 @@ TEST_P(StorageTypeGraphTest, NodeFeaturesMultipleNodesSingleFeatureMissingNode)
     TestGraph::MemoryGraph m;
     std::vector<std::vector<float>> f1 = {std::vector<float>{1.0f, 2.0f, 3.0f}};
     m.m_nodes.push_back(TestGraph::Node{.m_id = 0, .m_type = 0, .m_weight = 1.0f, .m_float_features = std::move(f1)});
-    auto path = std::filesystem::temp_directory_path();
+    auto path = std::filesystem::path(::testing::UnitTest::GetInstance()->current_test_info()->name());
+    assert(std::filesystem::create_directories(path));
     TestGraph::convert(path, "0_0", std::move(m), 2);
     snark::Metadata metadata(path.string());
     snark::Graph g(std::move(metadata), {path.string()}, std::vector<uint32_t>{0}, GetParam());
@@ -398,7 +401,8 @@ TEST_P(StorageTypeGraphTest, NodeFeaturesLongFeatureList)
         feature_data.emplace_back(std::vector<float>{float(i), float(i + 1), float(i + 2)});
     }
     m.m_nodes.push_back(TestGraph::Node{.m_id = 0, .m_type = 0, .m_weight = 1.0f, .m_float_features = feature_data});
-    auto path = std::filesystem::temp_directory_path();
+    auto path = std::filesystem::path(::testing::UnitTest::GetInstance()->current_test_info()->name());
+    assert(std::filesystem::create_directories(path));
     TestGraph::convert(path, "0_0", std::move(m), 2);
     snark::Metadata metadata(path.string());
     snark::Graph g(std::move(metadata), {path.string()}, std::vector<uint32_t>{0}, GetParam());
@@ -435,7 +439,8 @@ TEST_P(StorageTypeGraphTest, NodeFeaturesMultipleNodesMissingFeature)
     m.m_nodes.push_back(TestGraph::Node{.m_id = 0, .m_type = 0, .m_weight = 1.0f, .m_float_features = f1});
     m.m_nodes.push_back(TestGraph::Node{.m_id = 1, .m_type = 1, .m_weight = 1.0f, .m_float_features = f2});
     m.m_nodes.push_back(TestGraph::Node{.m_id = 2, .m_type = 1, .m_weight = 1.0f, .m_float_features = f2});
-    auto path = std::filesystem::temp_directory_path();
+    auto path = std::filesystem::path(::testing::UnitTest::GetInstance()->current_test_info()->name());
+    assert(std::filesystem::create_directories(path));
     TestGraph::convert(path, "0_0", std::move(m), 2);
     snark::Metadata metadata(path.string());
     snark::Graph g(std::move(metadata), {path.string()}, std::vector<uint32_t>{0}, GetParam());
@@ -459,7 +464,8 @@ TEST_P(StorageTypeGraphTest, NodeFeaturesMultipleNodesWithDifferentFeatureTimest
     m.m_nodes.push_back(TestGraph::Node{.m_id = 0, .m_type = 0, .m_weight = 1.0f, .m_float_features = f1});
     m.m_nodes.push_back(TestGraph::Node{.m_id = 1, .m_type = 1, .m_weight = 1.0f, .m_float_features = f2});
     m.m_nodes.push_back(TestGraph::Node{.m_id = 2, .m_type = 1, .m_weight = 1.0f, .m_float_features = f2});
-    auto path = std::filesystem::temp_directory_path();
+    auto path = std::filesystem::path(::testing::UnitTest::GetInstance()->current_test_info()->name());
+    assert(std::filesystem::create_directories(path));
     TestGraph::convert(path, "0_0", std::move(m), 2);
     snark::Metadata metadata(path.string());
     snark::Graph g(std::move(metadata), {path.string()}, std::vector<uint32_t>{0}, GetParam());
@@ -519,7 +525,8 @@ TEST_P(StorageTypeGraphTest, NodeFeaturesMultipleNodesSingleFeatureMixedSizes)
     std::vector<std::vector<float>> f2 = {std::vector<float>{11.0f, 12.0f}};
     m.m_nodes.push_back(TestGraph::Node{.m_id = 0, .m_type = 0, .m_weight = 1.0f, .m_float_features = f1});
     m.m_nodes.push_back(TestGraph::Node{.m_id = 1, .m_type = 1, .m_weight = 1.0f, .m_float_features = f2});
-    auto path = std::filesystem::temp_directory_path();
+    auto path = std::filesystem::path(::testing::UnitTest::GetInstance()->current_test_info()->name());
+    assert(std::filesystem::create_directories(path));
     TestGraph::convert(path, "0_0", std::move(m), 2);
     snark::Metadata metadata(path.string());
     snark::Graph g(std::move(metadata), {path.string()}, std::vector<uint32_t>{0}, GetParam());
@@ -552,7 +559,8 @@ TEST_P(StorageTypeGraphTest, NodeSparseFeaturesMultipleNodes)
     std::vector<std::vector<float>> f2 = {std::vector<float>(start, start + f2_data.size())};
     m.m_nodes.push_back(TestGraph::Node{.m_id = 0, .m_type = 0, .m_weight = 1.0f, .m_float_features = f1});
     m.m_nodes.push_back(TestGraph::Node{.m_id = 1, .m_type = 1, .m_weight = 1.0f, .m_float_features = f2});
-    auto path = std::filesystem::temp_directory_path();
+    auto path = std::filesystem::path(::testing::UnitTest::GetInstance()->current_test_info()->name());
+    assert(std::filesystem::create_directories(path));
     TestGraph::convert(path, "0_0", std::move(m), 2);
     snark::Metadata metadata(path.string());
     snark::Graph g(std::move(metadata), {path.string()}, std::vector<uint32_t>{0}, GetParam());
@@ -590,7 +598,8 @@ TEST_P(StorageTypeGraphTest, NodeSparseFeaturesMixedDimensions)
     f2.emplace_back(start, start + f2_2_data.size());
     m.m_nodes.push_back(TestGraph::Node{.m_id = 0, .m_type = 0, .m_weight = 1.0f, .m_float_features = f1});
     m.m_nodes.push_back(TestGraph::Node{.m_id = 1, .m_type = 1, .m_weight = 1.0f, .m_float_features = f2});
-    auto path = std::filesystem::temp_directory_path();
+    auto path = std::filesystem::path(::testing::UnitTest::GetInstance()->current_test_info()->name());
+    assert(std::filesystem::create_directories(path));
     TestGraph::convert(path, "0_0", std::move(m), 2);
     snark::Metadata metadata(path.string());
     snark::Graph g(std::move(metadata), {path.string()}, std::vector<uint32_t>{0}, GetParam());
@@ -621,7 +630,8 @@ TEST_P(StorageTypeGraphTest, NodeSparseFeaturesMissingFeature)
     std::vector<std::vector<float>> f1 = {std::vector<float>(start, start + feature_data.size())};
     m.m_nodes.push_back(TestGraph::Node{.m_id = 0, .m_type = 0, .m_weight = 1.0f, .m_float_features = f1});
     m.m_nodes.push_back(TestGraph::Node{.m_id = 1, .m_type = 1, .m_weight = 1.0f});
-    auto path = std::filesystem::temp_directory_path();
+    auto path = std::filesystem::path(::testing::UnitTest::GetInstance()->current_test_info()->name());
+    assert(std::filesystem::create_directories(path));
     TestGraph::convert(path, "0_0", std::move(m), 2);
     snark::Metadata metadata(path.string());
     snark::Graph g(std::move(metadata), {path.string()}, std::vector<uint32_t>{0}, GetParam());
@@ -657,7 +667,8 @@ TEST_P(StorageTypeGraphTest, NodeSparseFeaturesDimensionsFill)
     TestGraph::MemoryGraph m;
     m.m_nodes.push_back(TestGraph::Node{
         .m_id = snark::NodeId(13979298), .m_type = 0, .m_weight = 1.0f, .m_float_features = std::move(input_features)});
-    auto path = std::filesystem::temp_directory_path();
+    auto path = std::filesystem::path(::testing::UnitTest::GetInstance()->current_test_info()->name());
+    assert(std::filesystem::create_directories(path));
     auto partition = TestGraph::convert(path, "0_0", std::move(m), 1);
     snark::Metadata metadata(path.string());
     snark::Graph g(std::move(metadata), {path.string()}, std::vector<uint32_t>{0}, GetParam());
@@ -727,7 +738,8 @@ TEST_P(StorageTypeGraphTest, NodeStringFeaturesMultipleNodesSingleFeature)
     m.m_nodes.push_back(TestGraph::Node{.m_id = 0, .m_type = 0, .m_weight = 1.0f, .m_float_features = f1});
     m.m_nodes.push_back(TestGraph::Node{.m_id = 1, .m_type = 1, .m_weight = 1.0f});
     m.m_nodes.push_back(TestGraph::Node{.m_id = 2, .m_type = 1, .m_weight = 1.0f, .m_float_features = f2});
-    auto path = std::filesystem::temp_directory_path();
+    auto path = std::filesystem::path(::testing::UnitTest::GetInstance()->current_test_info()->name());
+    assert(std::filesystem::create_directories(path));
     TestGraph::convert(path, "0_0", std::move(m), 2);
     snark::Metadata metadata(path.string());
     snark::Graph g(std::move(metadata), {path.string()}, std::vector<uint32_t>{0}, GetParam());
@@ -763,7 +775,8 @@ TEST_P(StorageTypeGraphTest, NodeStringFeaturesWithDifferentTimestampsOnSeparate
     m3.m_nodes.push_back(TestGraph::Node{.m_id = 0, .m_type = 1, .m_weight = 1.0f, .m_float_features = f2});
     m3.m_nodes.push_back(TestGraph::Node{.m_id = 1, .m_type = 1, .m_weight = 1.0f});
 
-    auto path = std::filesystem::temp_directory_path();
+    auto path = std::filesystem::path(::testing::UnitTest::GetInstance()->current_test_info()->name());
+    assert(std::filesystem::create_directories(path));
     TestGraph::convert(path, "0_0", std::move(m1), 2);
     TestGraph::convert(path, "1_0", std::move(m2), 2);
     TestGraph::convert(path, "2_0", std::move(m3), 2);
@@ -788,7 +801,8 @@ TEST_P(StorageTypeGraphTest, NeighborSamplesWithSingleNodeNoNeighbors)
     TestGraph::MemoryGraph m;
     m.m_nodes.push_back(TestGraph::Node{.m_id = 0, .m_type = 0, .m_weight = 1.0f});
     m.m_nodes.push_back(TestGraph::Node{.m_id = 1, .m_type = 1, .m_weight = 1.0f});
-    auto path = std::filesystem::temp_directory_path();
+    auto path = std::filesystem::path(::testing::UnitTest::GetInstance()->current_test_info()->name());
+    assert(std::filesystem::create_directories(path));
     TestGraph::convert(path, "0_0", std::move(m), 2);
     snark::Metadata metadata(path.string());
     snark::Graph g(std::move(metadata), {path.string()}, std::vector<uint32_t>{0}, GetParam());
@@ -822,7 +836,8 @@ TEST(GraphTest, NeighborSampleSimple)
         .m_weight = 1.0f,
         .m_neighbors{std::vector<TestGraph::NeighborRecord>{{5, 0, 1.0f}, {6, 0, 1.0f}, {7, 0, 1.0f}, {8, 0, 1.0f}}}});
 
-    auto path = std::filesystem::temp_directory_path();
+    auto path = std::filesystem::path(::testing::UnitTest::GetInstance()->current_test_info()->name());
+    assert(std::filesystem::create_directories(path));
     TestGraph::convert(path, "0_0", std::move(m), 2);
     snark::Metadata metadata(path.string());
 
@@ -858,7 +873,8 @@ TEST_P(StorageTypeGraphTest, NeighborSampleMultipleTypesSinglePartition)
         .m_type = 1,
         .m_weight = 1.0f,
         .m_neighbors{std::vector<TestGraph::NeighborRecord>{{6, 0, 1.0f}, {7, 0, 1.0f}, {8, 0, 1.0f}}}});
-    auto path = std::filesystem::temp_directory_path();
+    auto path = std::filesystem::path(::testing::UnitTest::GetInstance()->current_test_info()->name());
+    assert(std::filesystem::create_directories(path));
     TestGraph::convert(path, "0_0", std::move(m), 2);
     snark::Metadata metadata(path.string());
     snark::Graph g(std::move(metadata), {path.string()}, std::vector<uint32_t>{0}, GetParam());
@@ -895,7 +911,9 @@ TEST(GraphTest, NeighborSampleMultipleTypesMultiplePartitions)
         .m_type = -1,
         .m_weight = 1.0f,
         .m_neighbors{std::vector<TestGraph::NeighborRecord>{{3, 0, 1.0f}, {4, 0, 3.0f}, {5, 1, 0.5f}, {6, 1, 2.0f}}}});
-    auto path = std::filesystem::temp_directory_path();
+    auto path =
+        std::filesystem::path(std::string(::testing::UnitTest::GetInstance()->current_test_info()->name()) + "_tst");
+    assert(std::filesystem::create_directories(path));
     TestGraph::convert(path, "0_0", std::move(m1), 3);
     TestGraph::convert(path, "1_0", std::move(m2), 3);
     snark::Metadata metadata(path.string());
@@ -932,7 +950,8 @@ TEST(GraphTest, NeighborSampleMultipleTypesNeighborsSpreadAcrossPartitions)
     TestGraph::MemoryGraph m2;
     m2.m_nodes.push_back(TestGraph::Node{
         .m_id = 1, .m_type = 1, .m_neighbors{std::vector<TestGraph::NeighborRecord>{{6, 1, 1.5f}, {7, 1, 3.0f}}}});
-    auto path = std::filesystem::temp_directory_path();
+    auto path = std::filesystem::path(::testing::UnitTest::GetInstance()->current_test_info()->name());
+    assert(std::filesystem::create_directories(path));
 
     TestGraph::convert(path, "0_0", std::move(m1), 2);
     TestGraph::convert(path, "1_0", std::move(m2), 2);
@@ -971,7 +990,8 @@ TEST(GraphTest, StatisticalNeighborSampleMultipleTypesNeighborsSpreadAcrossParti
     TestGraph::MemoryGraph m2;
     m2.m_nodes.push_back(TestGraph::Node{
         .m_id = 1, .m_type = -1, .m_neighbors{std::vector<TestGraph::NeighborRecord>{{6, 1, 1.0f}, {7, 1, 1.0f}}}});
-    auto path = std::filesystem::temp_directory_path();
+    auto path = std::filesystem::path(::testing::UnitTest::GetInstance()->current_test_info()->name());
+    assert(std::filesystem::create_directories(path));
     TestGraph::convert(path, "0_0", std::move(m1), 2);
     TestGraph::convert(path, "1_0", std::move(m2), 2);
     snark::Metadata metadata(path.string());
@@ -1020,7 +1040,8 @@ TEST(GraphTest, UniformNeighborSampleMultipleTypesNeighborsSpreadAcrossPartition
     TestGraph::MemoryGraph m2;
     m2.m_nodes.push_back(TestGraph::Node{
         .m_id = 1, .m_type = -1, .m_neighbors{std::vector<TestGraph::NeighborRecord>{{6, 1, 1.5f}, {7, 1, 3.0f}}}});
-    auto path = std::filesystem::temp_directory_path();
+    auto path = std::filesystem::path(::testing::UnitTest::GetInstance()->current_test_info()->name());
+    assert(std::filesystem::create_directories(path));
     TestGraph::convert(path, "0_0", std::move(m1), 2);
     TestGraph::convert(path, "1_0", std::move(m2), 2);
     snark::Metadata metadata(path.string());
@@ -1061,7 +1082,8 @@ TEST(GraphTest, NodeTypesMultipleTypesNeighborsSpreadAcrossPartitions)
         .m_id = 1, .m_type = -1, .m_neighbors{std::vector<TestGraph::NeighborRecord>{{6, 1, 1.5f}, {7, 1, 3.0f}}}});
     m2.m_nodes.push_back(TestGraph::Node{
         .m_id = 2, .m_type = 2, .m_neighbors{std::vector<TestGraph::NeighborRecord>{{6, 1, 1.5f}, {7, 1, 3.0f}}}});
-    auto path = std::filesystem::temp_directory_path();
+    auto path = std::filesystem::path(::testing::UnitTest::GetInstance()->current_test_info()->name());
+    assert(std::filesystem::create_directories(path));
 
     TestGraph::convert(path, "0_0", std::move(m1), 3);
     TestGraph::convert(path, "1_0", std::move(m2), 3);
@@ -1088,7 +1110,8 @@ TEST(GraphTest, NodeFeaturesMultipleTypesNeighborsSpreadAcrossPartitions)
     TestGraph::MemoryGraph m2;
     m2.m_nodes.push_back(TestGraph::Node{.m_id = 1, .m_type = -1});
     m2.m_nodes.push_back(TestGraph::Node{.m_id = 2, .m_type = 2, .m_float_features = f2});
-    auto path = std::filesystem::temp_directory_path();
+    auto path = std::filesystem::path(::testing::UnitTest::GetInstance()->current_test_info()->name());
+    assert(std::filesystem::create_directories(path));
 
     TestGraph::convert(path, "0_0", std::move(m1), 3);
     TestGraph::convert(path, "1_0", std::move(m2), 3);
@@ -1121,7 +1144,8 @@ TEST(GraphTest, NodeStringFeaturesMultipleTypesNeighborsSpreadAcrossPartitions)
     TestGraph::MemoryGraph m2;
     m2.m_nodes.push_back(TestGraph::Node{.m_id = 1, .m_type = -1});
     m2.m_nodes.push_back(TestGraph::Node{.m_id = 2, .m_type = 2, .m_float_features = f2});
-    auto path = std::filesystem::temp_directory_path();
+    auto path = std::filesystem::path(::testing::UnitTest::GetInstance()->current_test_info()->name());
+    assert(std::filesystem::create_directories(path));
 
     TestGraph::convert(path, "0_0", std::move(m1), 3);
     TestGraph::convert(path, "1_0", std::move(m2), 3);
@@ -1163,7 +1187,8 @@ TEST(GraphTest, NodeSparseFeaturesMultipleTypesNeighborsSpreadAcrossPartitions)
     TestGraph::MemoryGraph m2;
     m2.m_nodes.push_back(TestGraph::Node{.m_id = 1, .m_type = -1});
     m2.m_nodes.push_back(TestGraph::Node{.m_id = 2, .m_type = 2, .m_weight = 1.0f, .m_float_features = f2});
-    auto path = std::filesystem::temp_directory_path();
+    auto path = std::filesystem::path(::testing::UnitTest::GetInstance()->current_test_info()->name());
+    assert(std::filesystem::create_directories(path));
 
     TestGraph::convert(path, "0_0", std::move(m1), 3);
     TestGraph::convert(path, "1_0", std::move(m2), 3);
@@ -1219,7 +1244,8 @@ TEST(GraphTest, NodeSparseFeaturesMultipleTimestampsSpreadAcrossPartitions)
     m2.m_nodes.push_back(TestGraph::Node{.m_id = 1, .m_type = 1});
     m2.m_nodes.push_back(TestGraph::Node{.m_id = 2, .m_type = 2, .m_weight = 1.0f, .m_float_features = f2});
     m2.m_nodes.push_back(TestGraph::Node{.m_id = 3, .m_type = 2, .m_weight = 1.0f, .m_float_features = f3});
-    auto path = std::filesystem::temp_directory_path();
+    auto path = std::filesystem::path(::testing::UnitTest::GetInstance()->current_test_info()->name());
+    assert(std::filesystem::create_directories(path));
 
     TestGraph::convert(path, "0_0", std::move(m1), 3);
     TestGraph::convert(path, "1_0", std::move(m2), 3);
@@ -1266,7 +1292,8 @@ TEST(GraphTest, UniformNeighborSampleMultipleTypesTriggerConditionalProbabilitie
         .m_type = 0,
         .m_weight = 1.0f,
         .m_neighbors{std::vector<TestGraph::NeighborRecord>{{3, 0, 1.0f}, {4, 0, 1.0f}, {5, 1, 1.0f}}}});
-    auto path = std::filesystem::temp_directory_path();
+    auto path = std::filesystem::path(::testing::UnitTest::GetInstance()->current_test_info()->name());
+    assert(std::filesystem::create_directories(path));
     TestGraph::convert(path, "0_0", std::move(m1), 1);
     snark::Metadata metadata(path.string());
     snark::Graph g(std::move(metadata), {path.string()}, {0}, snark::PartitionStorageType::memory);
@@ -1301,7 +1328,8 @@ TEST(GraphTest, StatisticalUniformNeighborSampleSingleTypeNeighborSpreadAcrossPa
         .m_id = 1,
         .m_type = 1,
         .m_neighbors{std::vector<TestGraph::NeighborRecord>{{6, 1, 1.0f}, {7, 1, 1.0f}, {8, 1, 1.0f}}}});
-    auto path = std::filesystem::temp_directory_path();
+    auto path = std::filesystem::path(::testing::UnitTest::GetInstance()->current_test_info()->name());
+    assert(std::filesystem::create_directories(path));
     TestGraph::convert(path, "0_0", std::move(m1), 2);
     TestGraph::convert(path, "1_0", std::move(m2), 2);
     snark::Metadata metadata(path.string());
@@ -1364,7 +1392,8 @@ TEST(GraphTest, StatisticalUniformNeighborSampleMultipleTypesNeighborsSpreadAcro
         .m_id = 1,
         .m_type = 1,
         .m_neighbors{std::vector<TestGraph::NeighborRecord>{{7, 1, 1.0f}, {8, 1, 1.0f}, {9, 1, 1.0f}}}});
-    auto path = std::filesystem::temp_directory_path();
+    auto path = std::filesystem::path(::testing::UnitTest::GetInstance()->current_test_info()->name());
+    assert(std::filesystem::create_directories(path));
     TestGraph::convert(path, "0_0", std::move(m1), 2);
     TestGraph::convert(path, "1_0", std::move(m2), 2);
     snark::Metadata metadata(path.string());
@@ -1424,7 +1453,8 @@ TEST(GraphTest, GetNeighborsMultipleTypesNeighborsSpreadAcrossPartitions)
     TestGraph::MemoryGraph m2;
     m2.m_nodes.push_back(TestGraph::Node{
         .m_id = 1, .m_type = 1, .m_neighbors{std::vector<TestGraph::NeighborRecord>{{6, 1, 1.5f}, {7, 1, 3.0f}}}});
-    auto path = std::filesystem::temp_directory_path();
+    auto path = std::filesystem::path(::testing::UnitTest::GetInstance()->current_test_info()->name());
+    assert(std::filesystem::create_directories(path));
     TestGraph::convert(path, "0_0", std::move(m1), 2);
     TestGraph::convert(path, "1_0", std::move(m2), 2);
     snark::Metadata metadata(path.string());
@@ -1456,7 +1486,8 @@ TEST(GraphTest, GetNodeTypesAcrossPartitions)
     {
         m2.m_nodes.push_back(TestGraph::Node{.m_id = id, .m_type = int32_t(id % 3)});
     }
-    auto path = std::filesystem::temp_directory_path();
+    auto path = std::filesystem::path(::testing::UnitTest::GetInstance()->current_test_info()->name());
+    assert(std::filesystem::create_directories(path));
     TestGraph::convert(path, "0_0", std::move(m1), 3);
     TestGraph::convert(path, "1_0", std::move(m2), 3);
     snark::Metadata metadata(path.string());
@@ -1508,7 +1539,8 @@ TEST(GraphTest, GetNeigborCountSinglePartition)
         .m_neighbors{std::vector<TestGraph::NeighborRecord>{{3, 0, 1.0f}, {4, 0, 1.0f}, {5, 1, 1.0f}}}});
 
     // Initialize graph
-    auto path = std::filesystem::temp_directory_path();
+    auto path = std::filesystem::path(::testing::UnitTest::GetInstance()->current_test_info()->name());
+    assert(std::filesystem::create_directories(path));
     TestGraph::convert(path, "0_0", std::move(m1), 2);
     snark::Metadata metadata(path.string());
     snark::Graph g(std::move(metadata), {path.string()}, {0}, snark::PartitionStorageType::memory);
@@ -1605,7 +1637,8 @@ TEST(GraphTest, GetNeigborCountMultiplePartitions)
         .m_id = 1, .m_type = 1, .m_neighbors{std::vector<TestGraph::NeighborRecord>{{6, 1, 1.5f}, {7, 1, 3.0f}}}});
 
     // Initialize Graph
-    auto path = std::filesystem::temp_directory_path();
+    auto path = std::filesystem::path(::testing::UnitTest::GetInstance()->current_test_info()->name());
+    assert(std::filesystem::create_directories(path));
     TestGraph::convert(path, "0_0", std::move(m1), 2);
     TestGraph::convert(path, "1_0", std::move(m2), 2);
     snark::Metadata metadata(path.string());

--- a/src/cc/tests/mocks.h
+++ b/src/cc/tests/mocks.h
@@ -26,7 +26,10 @@ struct Node
 struct MemoryGraph
 {
     std::vector<Node> m_nodes;
-    snark::Timestamp m_watermark = -1;
+
+    // Temporal information.
+    snark::Timestamp m_watermark = -1; // use -1 to flag a non-temporal graph.
+    std::vector<std::pair<snark::Timestamp, snark::Timestamp>> m_edge_timestamps;
 };
 
 snark::Partition convert(std::filesystem::path path, std::string suffix, MemoryGraph t, size_t node_types);

--- a/src/cc/tests/temporal_test.cc
+++ b/src/cc/tests/temporal_test.cc
@@ -1,0 +1,530 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "src/cc/lib/distributed/client.h"
+#include "src/cc/lib/distributed/server.h"
+#include "src/cc/lib/graph/graph.h"
+#include "src/cc/lib/graph/partition.h"
+#include "src/cc/lib/graph/sampler.h"
+#include "src/cc/lib/graph/xoroshiro.h"
+#include "src/cc/tests/mocks.h"
+
+#include <algorithm>
+#include <array>
+#include <cassert>
+#include <cstdio>
+#include <filesystem>
+#include <span>
+#include <vector>
+
+#include "boost/random/uniform_int_distribution.hpp"
+#include "gtest/gtest.h"
+
+class TemporalTest : public ::testing::Test
+{
+  protected:
+    std::filesystem::path m_path;
+    std::unique_ptr<snark::Graph> m_single_partition_graph;
+    std::unique_ptr<snark::Graph> m_multi_partition_graph;
+    std::vector<std::shared_ptr<snark::GRPCServer>> m_servers;
+    std::shared_ptr<snark::GRPCClient> m_distributed_graph;
+
+    void SetUp() override
+    {
+        m_path = std::filesystem::temp_directory_path() / "TemporalTests";
+        std::filesystem::create_directory(m_path);
+        {
+            TestGraph::MemoryGraph m1;
+            m1.m_nodes.push_back(
+                TestGraph::Node{.m_id = 0,
+                                .m_type = 0,
+                                .m_weight = 1.0f,
+                                .m_neighbors{std::vector<TestGraph::NeighborRecord>{{1, 0, 1.0f}, {2, 0, 2.0f}}}});
+
+            m1.m_nodes.push_back(TestGraph::Node{
+                .m_id = 1,
+                .m_type = 1,
+                .m_weight = 1.0f,
+                .m_neighbors{std::vector<TestGraph::NeighborRecord>{{3, 0, 1.0f}, {4, 0, 1.0f}, {5, 1, 7.0f}}}});
+
+            m1.m_watermark = 1;
+            using ts_pair = std::pair<snark::Timestamp, snark::Timestamp>;
+            m1.m_edge_timestamps.emplace_back(ts_pair{0, 1});
+            m1.m_edge_timestamps.emplace_back(ts_pair{0, 1});
+            m1.m_edge_timestamps.emplace_back(ts_pair{0, 1});
+            m1.m_edge_timestamps.emplace_back(ts_pair{1, 2});
+            m1.m_edge_timestamps.emplace_back(ts_pair{2, 3});
+
+            // Initialize graph
+            auto path = m_path / "single_partition";
+            std::filesystem::create_directory(path);
+            TestGraph::convert(path, "0_0", std::move(m1), 2);
+            snark::Metadata metadata(path.string());
+            m_single_partition_graph =
+                std::make_unique<snark::Graph>(std::move(metadata), std::vector<std::string>{path.string()},
+                                               std::vector<uint32_t>{0}, snark::PartitionStorageType::memory);
+        }
+        {
+            auto path = m_path / "multi_partition";
+            std::filesystem::create_directory(path);
+            TestGraph::MemoryGraph m1;
+            m1.m_nodes.push_back(
+                TestGraph::Node{.m_id = 0,
+                                .m_type = 0,
+                                .m_weight = 1.0f,
+                                .m_neighbors{std::vector<TestGraph::NeighborRecord>{{1, 0, 1.0f}, {2, 0, 2.0f}}}});
+
+            m1.m_nodes.push_back(TestGraph::Node{
+                .m_id = 1,
+                .m_type = 1,
+                .m_weight = 1.0f,
+                .m_neighbors{std::vector<TestGraph::NeighborRecord>{{3, 0, 1.0f}, {4, 0, 1.0f}, {5, 1, 1.0f}}}});
+
+            m1.m_watermark = 2;
+            using ts_pair = std::pair<snark::Timestamp, snark::Timestamp>;
+            m1.m_edge_timestamps.emplace_back(ts_pair{0, 1});
+            m1.m_edge_timestamps.emplace_back(ts_pair{0, 1});
+            m1.m_edge_timestamps.emplace_back(ts_pair{0, 1});
+            m1.m_edge_timestamps.emplace_back(ts_pair{1, -1});
+            m1.m_edge_timestamps.emplace_back(ts_pair{1, -1});
+            TestGraph::MemoryGraph m2;
+            m2.m_nodes.push_back(
+                TestGraph::Node{.m_id = 1,
+                                .m_type = 1,
+                                .m_neighbors{std::vector<TestGraph::NeighborRecord>{{6, 1, 1.5f}, {7, 1, 3.0f}}}});
+
+            m2.m_watermark = 3;
+            m2.m_edge_timestamps.emplace_back(ts_pair{0, 1});
+            m2.m_edge_timestamps.emplace_back(ts_pair{2, 3});
+
+            // Initialize Graph
+            TestGraph::convert(path, "0_0", std::move(m1), 2);
+            TestGraph::convert(path, "1_0", std::move(m2), 2);
+            snark::Metadata metadata(path.string());
+            m_multi_partition_graph = std::make_unique<snark::Graph>(
+                std::move(metadata), std::vector<std::string>{path.string(), path.string()},
+                std::vector<uint32_t>{0, 1}, snark::PartitionStorageType::memory);
+        }
+        {
+            // Reuse data from multiparittion in memory graph.
+            std::vector<std::shared_ptr<grpc::Channel>> channels;
+            auto path = m_path / "multi_partition";
+            for (uint32_t server_index = 0; server_index < 2; ++server_index)
+            {
+                auto service = std::make_shared<snark::GraphEngineServiceImpl>(
+                    snark::Metadata(path.string()), std::vector<std::string>{path.string()},
+                    std::vector<uint32_t>{server_index}, snark::PartitionStorageType::memory);
+                m_servers.push_back(std::make_shared<snark::GRPCServer>(
+                    std::move(service), std::shared_ptr<snark::GraphSamplerServiceImpl>{}, std::string{"localhost:0"},
+                    std::string{}, std::string{}, std::string{}));
+                channels.emplace_back(m_servers.back()->InProcessChannel());
+            }
+
+            m_distributed_graph = std::make_shared<snark::GRPCClient>(std::move(channels), 1, 1);
+        }
+    }
+
+    void TearDown() override
+    {
+        // Disconnect client before shutting down servers(will happen automatically in destructors).
+        m_distributed_graph.reset();
+
+        std::filesystem::remove_all(m_path);
+    }
+};
+
+// Neighbor Count Tests
+TEST_F(TemporalTest, GetNeigborCountSinglePartition)
+{
+    // Check for singe edge type filter
+    std::vector<snark::NodeId> nodes = {0, 1};
+    std::vector<snark::Type> types = {0};
+    std::vector<uint64_t> output_neighbors_count(nodes.size());
+    std::vector<snark::Timestamp> ts = {2, 2};
+
+    m_single_partition_graph->NeighborCount(std::span(nodes), std::span(types), std::span(ts), output_neighbors_count);
+    EXPECT_EQ(std::vector<uint64_t>({0, 0}), output_neighbors_count);
+
+    ts = {0, 0};
+    m_single_partition_graph->NeighborCount(std::span(nodes), std::span(types), std::span(ts), output_neighbors_count);
+    EXPECT_EQ(std::vector<uint64_t>({2, 1}), output_neighbors_count);
+
+    // Check for different singe edge type filter
+    types = {1};
+    ts = {2, 2};
+    std::fill_n(output_neighbors_count.begin(), 2, -1);
+
+    m_single_partition_graph->NeighborCount(std::span(nodes), std::span(types), std::span(ts), output_neighbors_count);
+    EXPECT_EQ(std::vector<uint64_t>({0, 1}), output_neighbors_count);
+
+    // Check for both edge types
+    types = {0, 1};
+    std::fill_n(output_neighbors_count.begin(), 2, -1);
+
+    m_single_partition_graph->NeighborCount(std::span(nodes), std::span(types), std::span(ts), output_neighbors_count);
+    EXPECT_EQ(std::vector<uint64_t>({0, 1}), output_neighbors_count);
+
+    // Check returns 0 for unsatisfying edge types
+    types = {-1, 100};
+    std::fill_n(output_neighbors_count.begin(), 2, -1);
+
+    m_single_partition_graph->NeighborCount(std::span(nodes), std::span(types), std::span(ts), output_neighbors_count);
+    EXPECT_EQ(std::vector<uint64_t>({0, 0}), output_neighbors_count);
+
+    // Invalid node ids
+    nodes = {99, 100};
+    types = {0, 1};
+    std::fill_n(output_neighbors_count.begin(), 2, -1);
+
+    m_single_partition_graph->NeighborCount(std::span(nodes), std::span(types), std::span(ts), output_neighbors_count);
+    EXPECT_EQ(std::vector<uint64_t>({0, 0}), output_neighbors_count);
+}
+
+TEST_F(TemporalTest, GetFullNeighborSinglePartition)
+{
+    // Check for singe edge type filter
+    std::vector<snark::NodeId> nodes = {0, 1};
+    std::vector<snark::Type> types = {0};
+    std::vector<uint64_t> output_neighbors_count(nodes.size());
+    std::vector<snark::Timestamp> ts = {2, 2};
+
+    std::vector<snark::NodeId> output_neighbor_ids;
+    std::vector<snark::Type> output_neighbor_types;
+    std::vector<float> output_neighbors_weights;
+    m_single_partition_graph->FullNeighbor(std::span(nodes), std::span(types), std::span(ts), output_neighbor_ids,
+                                           output_neighbor_types, output_neighbors_weights,
+                                           std::span(output_neighbors_count));
+    EXPECT_TRUE(output_neighbor_ids.empty());
+    EXPECT_TRUE(output_neighbor_types.empty());
+    EXPECT_TRUE(output_neighbors_weights.empty());
+    EXPECT_EQ(std::vector<uint64_t>({0, 0}), output_neighbors_count);
+
+    ts = {0, 0};
+    m_single_partition_graph->FullNeighbor(std::span(nodes), std::span(types), std::span(ts), output_neighbor_ids,
+                                           output_neighbor_types, output_neighbors_weights,
+                                           std::span(output_neighbors_count));
+    EXPECT_EQ(std::vector<snark::NodeId>({1, 2, 3}), output_neighbor_ids);
+    output_neighbor_ids.clear();
+    EXPECT_EQ(std::vector<snark::Type>({0, 0, 0}), output_neighbor_types);
+    output_neighbor_types.clear();
+    EXPECT_EQ(std::vector<float>({1.f, 2.f, 1.f}), output_neighbors_weights);
+    output_neighbors_weights.clear();
+    EXPECT_EQ(std::vector<uint64_t>({2, 1}), output_neighbors_count);
+    std::fill_n(output_neighbors_count.begin(), 2, -1);
+
+    // Check for different singe edge type filter
+    types = {1};
+    ts = {2, 2};
+    m_single_partition_graph->FullNeighbor(std::span(nodes), std::span(types), std::span(ts), output_neighbor_ids,
+                                           output_neighbor_types, output_neighbors_weights,
+                                           std::span(output_neighbors_count));
+    EXPECT_EQ(std::vector<snark::NodeId>({5}), output_neighbor_ids);
+    output_neighbor_ids.clear();
+    EXPECT_EQ(std::vector<snark::Type>({1}), output_neighbor_types);
+    output_neighbor_types.clear();
+    EXPECT_EQ(std::vector<float>({7.f}), output_neighbors_weights);
+    output_neighbors_weights.clear();
+    EXPECT_EQ(std::vector<uint64_t>({0, 1}), output_neighbors_count);
+    std::fill_n(output_neighbors_count.begin(), 2, -1);
+
+    // Check for both edge types
+    types = {0, 1};
+    m_single_partition_graph->FullNeighbor(std::span(nodes), std::span(types), std::span(ts), output_neighbor_ids,
+                                           output_neighbor_types, output_neighbors_weights,
+                                           std::span(output_neighbors_count));
+    EXPECT_EQ(std::vector<snark::NodeId>({5}), output_neighbor_ids);
+    output_neighbor_ids.clear();
+    EXPECT_EQ(std::vector<snark::Type>({1}), output_neighbor_types);
+    output_neighbor_types.clear();
+    EXPECT_EQ(std::vector<float>({7.f}), output_neighbors_weights);
+    output_neighbors_weights.clear();
+    EXPECT_EQ(std::vector<uint64_t>({0, 1}), output_neighbors_count);
+    std::fill_n(output_neighbors_count.begin(), 2, -1);
+
+    // Check returns 0 for unsatisfying edge types
+    types = {-1, 100};
+    std::fill_n(output_neighbors_count.begin(), 2, -1);
+
+    m_single_partition_graph->FullNeighbor(std::span(nodes), std::span(types), std::span(ts), output_neighbor_ids,
+                                           output_neighbor_types, output_neighbors_weights,
+                                           std::span(output_neighbors_count));
+    EXPECT_TRUE(output_neighbor_ids.empty());
+    EXPECT_TRUE(output_neighbor_types.empty());
+    EXPECT_TRUE(output_neighbors_weights.empty());
+    EXPECT_EQ(std::vector<uint64_t>({0, 0}), output_neighbors_count);
+
+    // Invalid node ids
+    nodes = {99, 100};
+    types = {0, 1};
+    std::fill_n(output_neighbors_count.begin(), 2, -1);
+
+    m_single_partition_graph->FullNeighbor(std::span(nodes), std::span(types), std::span(ts), output_neighbor_ids,
+                                           output_neighbor_types, output_neighbors_weights,
+                                           std::span(output_neighbors_count));
+    EXPECT_TRUE(output_neighbor_ids.empty());
+    EXPECT_TRUE(output_neighbor_types.empty());
+    EXPECT_TRUE(output_neighbors_weights.empty());
+    EXPECT_EQ(std::vector<uint64_t>({0, 0}), output_neighbors_count);
+}
+
+TEST_F(TemporalTest, GetNeigborCountMultiplePartitions)
+{
+    // Check for singe edge type filter
+    std::vector<snark::NodeId> nodes = {0, 1};
+    std::vector<snark::Type> types = {1};
+    std::vector<uint64_t> output_neighbors_count(nodes.size());
+
+    m_multi_partition_graph->NeighborCount(std::span(nodes), std::span(types), {}, output_neighbors_count);
+    EXPECT_EQ(std::vector<uint64_t>({0, 3}), output_neighbors_count);
+
+    // Check for multiple edge types
+    types = {0, 1};
+    std::fill_n(output_neighbors_count.begin(), 2, -1);
+
+    std::vector<snark::Timestamp> ts = {2, 2};
+    m_multi_partition_graph->NeighborCount(std::span(nodes), std::span(types), std::span(ts), output_neighbors_count);
+    EXPECT_EQ(std::vector<uint64_t>({0, 3}), output_neighbors_count);
+
+    // Check non-existent edge types functionality
+    types = {-1, 100};
+    std::fill_n(output_neighbors_count.begin(), 2, -1);
+
+    m_multi_partition_graph->NeighborCount(std::span(nodes), std::span(types), std::span(ts), output_neighbors_count);
+    EXPECT_EQ(std::vector<uint64_t>({0, 0}), output_neighbors_count);
+
+    // Check invalid node ids handling
+    nodes = {99, 100};
+    types = {0, 1};
+    std::fill_n(output_neighbors_count.begin(), 2, -1);
+
+    m_multi_partition_graph->NeighborCount(std::span(nodes), std::span(types), std::span(ts), output_neighbors_count);
+    EXPECT_EQ(std::vector<uint64_t>({0, 0}), output_neighbors_count);
+}
+
+TEST_F(TemporalTest, GetFullNeighborMultiplePartitions)
+{
+    // Check for singe edge type filter
+    std::vector<snark::NodeId> nodes = {0, 1};
+    std::vector<snark::Type> types = {1};
+    std::vector<uint64_t> output_neighbors_count(nodes.size());
+    std::vector<snark::Timestamp> ts = {2, 2};
+
+    std::vector<snark::NodeId> output_neighbor_ids;
+    std::vector<snark::Type> output_neighbor_types;
+    std::vector<float> output_neighbors_weights;
+    m_multi_partition_graph->FullNeighbor(std::span(nodes), std::span(types), std::span(ts), output_neighbor_ids,
+                                          output_neighbor_types, output_neighbors_weights,
+                                          std::span(output_neighbors_count));
+    EXPECT_EQ(std::vector<snark::NodeId>({5, 7}), output_neighbor_ids);
+    output_neighbor_ids.clear();
+    EXPECT_EQ(std::vector<snark::Type>({1, 1}), output_neighbor_types);
+    output_neighbor_types.clear();
+    EXPECT_EQ(std::vector<float>({1.f, 3.0f}), output_neighbors_weights);
+    output_neighbors_weights.clear();
+    EXPECT_EQ(std::vector<uint64_t>({0, 2}), output_neighbors_count);
+    std::fill_n(output_neighbors_count.begin(), 2, -1);
+
+    // Check for multiple edge types
+    types = {0, 1};
+    m_multi_partition_graph->FullNeighbor(std::span(nodes), std::span(types), std::span(ts), output_neighbor_ids,
+                                          output_neighbor_types, output_neighbors_weights,
+                                          std::span(output_neighbors_count));
+    EXPECT_EQ(std::vector<snark::NodeId>({4, 5, 7}), output_neighbor_ids);
+    output_neighbor_ids.clear();
+    EXPECT_EQ(std::vector<snark::Type>({0, 1, 1}), output_neighbor_types);
+    output_neighbor_types.clear();
+    EXPECT_EQ(std::vector<float>({1.f, 1.f, 3.f}), output_neighbors_weights);
+    output_neighbors_weights.clear();
+    EXPECT_EQ(std::vector<uint64_t>({0, 3}), output_neighbors_count);
+    std::fill_n(output_neighbors_count.begin(), 2, -1);
+
+    // Check for different singe edge type filter
+    types = {0};
+    ts = {2, 2};
+    m_multi_partition_graph->FullNeighbor(std::span(nodes), std::span(types), std::span(ts), output_neighbor_ids,
+                                          output_neighbor_types, output_neighbors_weights,
+                                          std::span(output_neighbors_count));
+    EXPECT_EQ(std::vector<snark::NodeId>({4}), output_neighbor_ids);
+    output_neighbor_ids.clear();
+    EXPECT_EQ(std::vector<snark::Type>({0}), output_neighbor_types);
+    output_neighbor_types.clear();
+    EXPECT_EQ(std::vector<float>({1.f}), output_neighbors_weights);
+    output_neighbors_weights.clear();
+    EXPECT_EQ(std::vector<uint64_t>({0, 1}), output_neighbors_count);
+    std::fill_n(output_neighbors_count.begin(), 2, -1);
+
+    // Check returns 0 for unsatisfying edge types
+    types = {-1, 100};
+    std::fill_n(output_neighbors_count.begin(), 2, -1);
+
+    m_multi_partition_graph->FullNeighbor(std::span(nodes), std::span(types), std::span(ts), output_neighbor_ids,
+                                          output_neighbor_types, output_neighbors_weights,
+                                          std::span(output_neighbors_count));
+    EXPECT_TRUE(output_neighbor_ids.empty());
+    EXPECT_TRUE(output_neighbor_types.empty());
+    EXPECT_TRUE(output_neighbors_weights.empty());
+    EXPECT_EQ(std::vector<uint64_t>({0, 0}), output_neighbors_count);
+
+    // Invalid node ids
+    nodes = {99, 100};
+    types = {0, 1};
+    std::fill_n(output_neighbors_count.begin(), 2, -1);
+
+    m_multi_partition_graph->FullNeighbor(std::span(nodes), std::span(types), std::span(ts), output_neighbor_ids,
+                                          output_neighbor_types, output_neighbors_weights,
+                                          std::span(output_neighbors_count));
+    EXPECT_TRUE(output_neighbor_ids.empty());
+    EXPECT_TRUE(output_neighbor_types.empty());
+    EXPECT_TRUE(output_neighbors_weights.empty());
+    EXPECT_EQ(std::vector<uint64_t>({0, 0}), output_neighbors_count);
+}
+
+TEST_F(TemporalTest, GetSampleNeighborsMultiplePartitions)
+{
+    // Check for singe edge type filter
+    std::vector<snark::NodeId> nodes = {0, 1};
+    std::vector<snark::Type> types = {1};
+    std::vector<snark::Timestamp> ts = {2, 2};
+    size_t sample_count = 2;
+
+    std::vector<snark::NodeId> output_neighbor_ids(sample_count * nodes.size());
+    std::vector<snark::Type> output_neighbor_types(sample_count * nodes.size());
+    std::vector<float> output_neighbors_weights(sample_count * nodes.size());
+    std::vector<float> output_neighbors_total_weights(nodes.size());
+    m_multi_partition_graph->SampleNeighbor(33, std::span(nodes), std::span(types), std::span(ts), sample_count,
+                                            std::span(output_neighbor_ids), std::span(output_neighbor_types),
+                                            std::span(output_neighbors_weights),
+                                            std::span(output_neighbors_total_weights), 42, 0.5f, 13);
+
+    // Only available neighbor based on time/type is 5
+    EXPECT_EQ(std::vector<snark::NodeId>({42, 42, 5, 5}), output_neighbor_ids);
+    std::fill(std::begin(output_neighbor_ids), std::end(output_neighbor_ids), -1);
+    EXPECT_EQ(std::vector<snark::Type>({13, 13, 1, 1}), output_neighbor_types);
+    std::fill(std::begin(output_neighbor_types), std::end(output_neighbor_types), -1);
+    EXPECT_EQ(std::vector<float>({0.5f, 0.5f, 1.f, 1.f}), output_neighbors_weights);
+    std::fill(std::begin(output_neighbors_weights), std::end(output_neighbors_weights), -1);
+    EXPECT_EQ(std::vector<float>({0.f, 4.0f}), output_neighbors_total_weights);
+    std::fill(std::begin(output_neighbors_total_weights), std::end(output_neighbors_total_weights), 0);
+
+    // Check for multiple edge types
+    types = {0, 1};
+    m_multi_partition_graph->SampleNeighbor(36, std::span(nodes), std::span(types), std::span(ts), sample_count,
+                                            std::span(output_neighbor_ids), std::span(output_neighbor_types),
+                                            std::span(output_neighbors_weights),
+                                            std::span(output_neighbors_total_weights), 42, 0.5f, 13);
+    EXPECT_EQ(std::vector<snark::NodeId>({42, 42, 7, 5}), output_neighbor_ids);
+    std::fill(std::begin(output_neighbor_ids), std::end(output_neighbor_ids), -1);
+    EXPECT_EQ(std::vector<snark::Type>({13, 13, 1, 1}), output_neighbor_types);
+    std::fill(std::begin(output_neighbor_types), std::end(output_neighbor_types), -1);
+    EXPECT_EQ(std::vector<float>({0.5f, 0.5f, 3.f, 1.f}), output_neighbors_weights);
+    std::fill(std::begin(output_neighbors_weights), std::end(output_neighbors_weights), -1);
+    EXPECT_EQ(std::vector<float>({0.f, 5.f}), output_neighbors_total_weights);
+    std::fill(std::begin(output_neighbors_total_weights), std::end(output_neighbors_total_weights), 0);
+
+    // Check for different singe edge type filter
+    types = {1};
+    ts = {0, 0};
+    m_multi_partition_graph->SampleNeighbor(37, std::span(nodes), std::span(types), std::span(ts), sample_count,
+                                            std::span(output_neighbor_ids), std::span(output_neighbor_types),
+                                            std::span(output_neighbors_weights),
+                                            std::span(output_neighbors_total_weights), 42, 0.5f, 13);
+    EXPECT_EQ(std::vector<snark::NodeId>({42, 42, 6, 6}), output_neighbor_ids);
+    std::fill(std::begin(output_neighbor_ids), std::end(output_neighbor_ids), -1);
+    EXPECT_EQ(std::vector<snark::Type>({13, 13, 1, 1}), output_neighbor_types);
+    std::fill(std::begin(output_neighbor_types), std::end(output_neighbor_types), -1);
+    EXPECT_EQ(std::vector<float>({0.5f, 0.5f, 1.5f, 1.5f}), output_neighbors_weights);
+    std::fill(std::begin(output_neighbors_weights), std::end(output_neighbors_weights), -1);
+    EXPECT_EQ(std::vector<float>({0.f, 1.5f}), output_neighbors_total_weights);
+    std::fill(std::begin(output_neighbors_total_weights), std::end(output_neighbors_total_weights), 0);
+
+    // Check returns 0 for unsatisfying edge types
+    types = {-1, 100};
+
+    m_multi_partition_graph->SampleNeighbor(33, std::span(nodes), std::span(types), std::span(ts), sample_count,
+                                            std::span(output_neighbor_ids), std::span(output_neighbor_types),
+                                            std::span(output_neighbors_weights),
+                                            std::span(output_neighbors_total_weights), 42, 0.5f, 13);
+    EXPECT_EQ(std::vector<snark::NodeId>({42, 42, 42, 42}), output_neighbor_ids);
+    std::fill(std::begin(output_neighbor_ids), std::end(output_neighbor_ids), -1);
+    EXPECT_EQ(std::vector<snark::Type>({13, 13, 13, 13}), output_neighbor_types);
+    std::fill(std::begin(output_neighbor_types), std::end(output_neighbor_types), -1);
+    EXPECT_EQ(std::vector<float>({0.5f, 0.5f, 0.5f, 0.5f}), output_neighbors_weights);
+    std::fill(std::begin(output_neighbors_weights), std::end(output_neighbors_weights), -1);
+    EXPECT_EQ(std::vector<float>({0.f, 0.f}), output_neighbors_total_weights);
+    std::fill(std::begin(output_neighbors_total_weights), std::end(output_neighbors_total_weights), 0);
+
+    // Invalid node ids
+    nodes = {99, 100};
+    types = {0, 1};
+
+    m_multi_partition_graph->SampleNeighbor(33, std::span(nodes), std::span(types), std::span(ts), sample_count,
+                                            std::span(output_neighbor_ids), std::span(output_neighbor_types),
+                                            std::span(output_neighbors_weights),
+                                            std::span(output_neighbors_total_weights), 42, 0.5f, 13);
+
+    EXPECT_EQ(std::vector<snark::NodeId>({42, 42, 42, 42}), output_neighbor_ids);
+    EXPECT_EQ(std::vector<snark::Type>({13, 13, 13, 13}), output_neighbor_types);
+    EXPECT_EQ(std::vector<float>({0.5f, 0.5f, 0.5f, 0.5f}), output_neighbors_weights);
+    EXPECT_EQ(std::vector<float>({0.f, 0.f}), output_neighbors_total_weights);
+}
+
+TEST_F(TemporalTest, GetFullNeighborDistributed)
+{
+    // Check for singe edge type filter
+    std::vector<snark::NodeId> nodes = {0, 1};
+    std::vector<snark::Type> types = {1};
+    std::vector<uint64_t> output_neighbors_count(nodes.size());
+    std::vector<snark::Timestamp> ts = {2, 2};
+
+    std::vector<snark::NodeId> output_neighbor_ids;
+    std::vector<snark::Type> output_neighbor_types;
+    std::vector<float> output_neighbors_weights;
+    m_distributed_graph->FullNeighbor(std::span(nodes), std::span(types), std::span(ts), output_neighbor_ids,
+                                      output_neighbor_types, output_neighbors_weights,
+                                      std::span(output_neighbors_count));
+    EXPECT_EQ(std::vector<snark::NodeId>({5, 7}), output_neighbor_ids);
+    EXPECT_EQ(std::vector<snark::Type>({1, 1}), output_neighbor_types);
+    EXPECT_EQ(std::vector<float>({1.f, 3.0f}), output_neighbors_weights);
+    EXPECT_EQ(std::vector<uint64_t>({0, 2}), output_neighbors_count);
+}
+
+TEST_F(TemporalTest, GetNeighborCountDistributed)
+{
+    std::vector<snark::NodeId> nodes = {0, 1};
+    std::vector<snark::Type> types = {1};
+    std::vector<uint64_t> output_neighbors_count(nodes.size());
+    std::vector<snark::Timestamp> ts = {2, 2};
+    m_distributed_graph->NeighborCount(std::span(nodes), std::span(types), std::span(ts),
+                                       std::span(output_neighbors_count));
+    EXPECT_EQ(std::vector<uint64_t>({0, 2}), output_neighbors_count);
+
+    types = {0, 1};
+    m_distributed_graph->NeighborCount(std::span(nodes), std::span(types), std::span(ts),
+                                       std::span(output_neighbors_count));
+    EXPECT_EQ(std::vector<uint64_t>({0, 3}), output_neighbors_count);
+}
+
+TEST_F(TemporalTest, GetSampleNeighborsDistributed)
+{
+    std::vector<snark::NodeId> nodes = {0, 1};
+    // Keep types = 0 to keep test stable and avoid merging neighbors from multiple shards.
+    std::vector<snark::Type> types = {0};
+    std::vector<snark::Timestamp> ts = {2, 2};
+    size_t sample_count = 2;
+
+    std::vector<snark::NodeId> output_neighbor_ids(sample_count * nodes.size());
+    std::vector<snark::Type> output_neighbor_types(sample_count * nodes.size());
+    std::vector<float> output_neighbors_weights(sample_count * nodes.size());
+    m_distributed_graph->WeightedSampleNeighbor(37, std::span(nodes), std::span(types), std::span(ts), sample_count,
+                                                std::span(output_neighbor_ids), std::span(output_neighbor_types),
+                                                std::span(output_neighbors_weights), 42, 0.5f, 13);
+    EXPECT_EQ(std::vector<snark::NodeId>({42, 42, 4, 4}), output_neighbor_ids);
+    EXPECT_EQ(std::vector<snark::Type>({13, 13, 0, 0}), output_neighbor_types);
+    EXPECT_EQ(std::vector<float>({0.5f, 0.5f, 1.f, 1.f}), output_neighbors_weights);
+}
+
+int main(int argc, char **argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
- [x] Forked repo is synced with upstream -> github shows no code delta outside of the desired.
    https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork
- [x] Tests are passing? https://github.com/microsoft/DeepGNN/blob/main/CONTRIBUTING.md#run-tests
- [x] Changelog and documentation updated.
- [x] PR is labeled using the label menu on the right side.

Implement sampling in temporal graphs via binary search: once we determine a position of node neighbors in the edge list, we'll use binary searches to find corresponding timestamps first and only then perform weighted/uniform/other sampling.
Python tests are expected to fail and will be fixed in part 4.