### PR TITLE
Drop no-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,6 @@ repos:
         -   id: forbid-new-submodules
         -   id: mixed-line-ending
         -   id: name-tests-test
-        -   id: no-commit-to-branch
         -   id: pretty-format-json
             args: ["--autofix"]
         -   id: requirements-txt-fixer


### PR DESCRIPTION
- [x] Forked repo is synced with upstream -> github shows no code delta outside of the desired.
    https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork
- [x] Tests are passing? https://github.com/microsoft/DeepGNN/blob/main/CONTRIBUTING.md#run-tests
- [x] Changelog and documentation updated.
- [x] PR is labeled using the label menu on the right side.

Previous Behavior
----------------
* Hook failing on a main branch

New Behavior
----------------
* Hook doesn't do much, because we are protected by github policies, so it is easier to just drop it.