### PR TITLE
Pick a single sparse feature from multiple servers.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Implement del method to release C++ client and server. Important for ray actors, because they create numerous clients during training.
 
+- If sparse feature values present on multiple servers, then only one will be returned with source picked randomly.
+
 ## [0.1.57] - 2022-12-15
 
 ### Changed

--- a/src/cc/lib/distributed/client.cc
+++ b/src/cc/lib/distributed/client.cc
@@ -138,7 +138,7 @@ void GetSparseFeature(const SparseRequest &request,
         }
 
         call->callback = [&reply = replies[shard], &response_index, shard, out_dimensions, &feature_source,
-                          feature_count, uninitialized_shard_index]() {
+                          feature_count]() {
             if (reply.indices().empty())
             {
                 return;

--- a/src/cc/lib/distributed/client.cc
+++ b/src/cc/lib/distributed/client.cc
@@ -111,6 +111,13 @@ void GetSparseFeature(const SparseRequest &request,
     std::vector<std::vector<SparseFeatureIndex>> response_index(input_size,
                                                                 std::vector<SparseFeatureIndex>(feature_count));
 
+    // We store source of feature values as atomic variable to avoid locking and construct indices concurrently.
+    const auto uninitialized_shard_index = std::numeric_limits<size_t>::max();
+    std::vector<std::atomic<size_t>> feature_source(input_size * feature_count);
+    for (auto &fs : feature_source)
+    {
+        fs.exchange(uninitialized_shard_index);
+    }
     for (size_t shard = 0; shard < engine_stubs.size(); ++shard)
     {
         auto *call = new AsyncClientCall();
@@ -130,7 +137,8 @@ void GetSparseFeature(const SparseRequest &request,
             throw std::runtime_error("Unknown request type for GetSparseFeature");
         }
 
-        call->callback = [&reply = replies[shard], &response_index, shard, out_dimensions]() {
+        call->callback = [&reply = replies[shard], &response_index, shard, out_dimensions, &feature_source,
+                          feature_count, uninitialized_shard_index]() {
             if (reply.indices().empty())
             {
                 return;
@@ -164,6 +172,15 @@ void GetSparseFeature(const SparseRequest &request,
                      node_offset += feature_dim, value_offset += value_increment)
                 {
                     const auto item_index = reply.indices(node_offset);
+                    size_t temp_shard = uninitialized_shard_index;
+                    const auto is_current_shard_source =
+                        feature_source[item_index * feature_count + feature_index].compare_exchange_strong(temp_shard,
+                                                                                                           shard);
+                    if (!is_current_shard_source && temp_shard != shard)
+                    {
+                        continue;
+                    }
+
                     int64_t count = std::get<2>(response_index[item_index][feature_index]);
                     if (count == 0)
                     {

--- a/src/cc/tests/distributed_test.cc
+++ b/src/cc/tests/distributed_test.cc
@@ -1076,7 +1076,8 @@ TEST(DistributedTest, NodeSameSparseFeaturesAcrossMultipleServers)
     };
 
     // indices - 1, 14, 20, data - 1,2,3
-    std::vector<int32_t> f3_data = {3, 1, 1, 0, 14, 0, 20, 0, 1, 0, 2, 0, 3};
+    // in python: struct.unpack('@iii', struct.pack("@fff", 1.0, 2.0, 3.0))
+    std::vector<int32_t> f3_data = {3, 1, 1, 0, 14, 0, 20, 0, 1065353216, 1073741824, 1077936128};
 
     std::vector<std::vector<std::vector<float>>> fv;
     auto start = reinterpret_cast<float *>(f0_data.data());


### PR DESCRIPTION
- [x] Forked repo is synced with upstream -> github shows no code delta outside of the desired.
    https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork
- [x] Tests are passing? https://github.com/microsoft/DeepGNN/blob/main/CONTRIBUTING.md#run-tests
- [x] Changelog and documentation updated.
- [x] PR is labeled using the label menu on the right side.

Previous Behavior
----------------
Sparse feature values were corrupted if it is present on multiple GE servers(with different values).

New Behavior
----------------
It is hard to control duplicate features across multiple GE server instances, we can pick a random value for sparse features.
In case of dense/string features, they are already overwritten, but for sparse features we were merging indices concurrently.
We pick a random source during feature extraction and stick to it until values returned to python.