### PR TITLE
add retry to snark client

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -69,3 +69,6 @@ ignore_missing_imports = True
 
 [mypy-pasta.*]
 ignore_missing_imports = True
+
+[mypy-tenacity.*]
+ignore_missing_imports = True

--- a/docs/BUILD
+++ b/docs/BUILD
@@ -27,6 +27,7 @@ py_test(
         requirement("opencensus"),
         requirement("opencensus-context"),
         requirement("opencensus-ext-azure"),
+        requirement("tenacity"),
     ],
 )
 
@@ -50,6 +51,7 @@ py_test(
         requirement("opencensus-context"),
         requirement("opencensus-ext-azure"),
         requirement("avro-python3"),
+        requirement("tenacity"),
     ],
 )
 
@@ -73,6 +75,7 @@ py_test(
         requirement("opencensus"),
         requirement("opencensus-context"),
         requirement("opencensus-ext-azure"),
+        requirement("tenacity"),
     ],
 )
 
@@ -96,6 +99,7 @@ py_test(
         requirement("opencensus-context"),
         requirement("opencensus-ext-azure"),
         requirement("pyspark"),
+        requirement("tenacity"),
     ],
 )
 
@@ -133,6 +137,7 @@ py_test(
         requirement("tensorflow"),
         requirement("transformers"),
         requirement("torch"),
+        requirement("tenacity"),
     ],
 )
 
@@ -170,6 +175,7 @@ py_test(
         requirement("tensorflow"),
         requirement("transformers"),
         requirement("torch"),
+        requirement("tenacity"),
     ],
 )
 
@@ -204,6 +210,7 @@ py_test(
         requirement("tensorflow"),
         requirement("transformers"),
         requirement("torch"),
+        requirement("tenacity"),
     ],
 )
 
@@ -238,6 +245,7 @@ py_test(
         requirement("tensorflow"),
         requirement("transformers"),
         requirement("torch"),
+        requirement("tenacity"),
     ],
 )
 
@@ -275,6 +283,7 @@ py_test(
         requirement("tensorflow"),
         requirement("transformers"),
         requirement("torch"),
+        requirement("tenacity"),
     ],
 )
 
@@ -312,6 +321,7 @@ py_test(
         requirement("tensorflow"),
         requirement("transformers"),
         requirement("torch"),
+        requirement("tenacity"),
     ],
 )
 
@@ -342,6 +352,7 @@ py_test(
         requirement("opencensus-ext-azure"),
         requirement("scikit-learn"),
         requirement("tensorflow"),
+        requirement("tenacity"),
     ],
 )
 
@@ -373,6 +384,7 @@ py_test(
         requirement("opencensus-ext-azure"),
         requirement("scikit-learn"),
         requirement("tensorflow"),
+        requirement("tenacity"),
     ],
 )
 
@@ -408,6 +420,7 @@ py_test(
         requirement("scikit-learn"),
         requirement("tensorflow"),
         requirement("torch"),
+        requirement("tenacity"),
     ],
 )
 

--- a/examples/pytorch/gat/BUILD
+++ b/examples/pytorch/gat/BUILD
@@ -43,5 +43,6 @@ py_test(
         requirement("opencensus-context"),
         requirement("opencensus-ext-azure"),
         requirement("azure-datalake-store"),
+        requirement("tenacity"),
     ],
 )

--- a/examples/pytorch/geometric/gat/BUILD
+++ b/examples/pytorch/geometric/gat/BUILD
@@ -47,5 +47,6 @@ py_test(
         requirement("torch-scatter"),
         requirement("torch-sparse"),
         requirement("torch_geometric"),
+        requirement("tenacity"),
     ],
 )

--- a/examples/pytorch/geometric/graphsage/BUILD
+++ b/examples/pytorch/geometric/graphsage/BUILD
@@ -48,5 +48,6 @@ py_test(
         requirement("torch-scatter"),
         requirement("torch-sparse"),
         requirement("torch_geometric"),
+        requirement("tenacity"),
     ],
 )

--- a/examples/pytorch/graphsage/BUILD
+++ b/examples/pytorch/graphsage/BUILD
@@ -47,5 +47,6 @@ py_test(
         requirement("opencensus-context"),
         requirement("opencensus-ext-azure"),
         requirement("azure-datalake-store"),
+        requirement("tenacity"),
     ],
 )

--- a/examples/pytorch/hetgnn/BUILD
+++ b/examples/pytorch/hetgnn/BUILD
@@ -48,6 +48,7 @@ py_test(
         requirement("opencensus-context"),
         requirement("opencensus-ext-azure"),
         requirement("azure-datalake-store"),
+        requirement("tenacity"),
     ],
 )
 
@@ -72,5 +73,6 @@ py_test(
         requirement("opencensus-context"),
         requirement("opencensus-ext-azure"),
         requirement("azure-datalake-store"),
+        requirement("tenacity"),
     ],
 )

--- a/examples/pytorch/knowledgegraph/BUILD
+++ b/examples/pytorch/knowledgegraph/BUILD
@@ -44,5 +44,6 @@ py_test(
         requirement("opencensus-context"),
         requirement("opencensus-ext-azure"),
         requirement("azure-datalake-store"),
+        requirement("tenacity"),
     ],
 )

--- a/examples/pytorch/link_prediction/BUILD
+++ b/examples/pytorch/link_prediction/BUILD
@@ -61,6 +61,7 @@ py_test(
         requirement("opencensus-context"),
         requirement("opencensus-ext-azure"),
         requirement("azure-datalake-store"),
+        requirement("tenacity"),
     ],
 )
 
@@ -87,5 +88,6 @@ py_test(
         requirement("opencensus-context"),
         requirement("opencensus-ext-azure"),
         requirement("azure-datalake-store"),
+        requirement("tenacity"),
     ],
 )

--- a/examples/tensorflow/gat/BUILD
+++ b/examples/tensorflow/gat/BUILD
@@ -39,5 +39,6 @@ py_test(
         requirement("opencensus-context"),
         requirement("opencensus-ext-azure"),
         requirement("azure-datalake-store"),
+        requirement("tenacity"),
     ],
 )

--- a/examples/tensorflow/gcn/BUILD
+++ b/examples/tensorflow/gcn/BUILD
@@ -39,5 +39,6 @@ py_test(
         requirement("opencensus-context"),
         requirement("opencensus-ext-azure"),
         requirement("azure-datalake-store"),
+        requirement("tenacity"),
     ],
 )

--- a/examples/tensorflow/han/BUILD
+++ b/examples/tensorflow/han/BUILD
@@ -40,5 +40,6 @@ py_test(
         requirement("opencensus-context"),
         requirement("opencensus-ext-azure"),
         requirement("azure-datalake-store"),
+        requirement("tenacity"),
     ],
 )

--- a/examples/tensorflow/sage/BUILD
+++ b/examples/tensorflow/sage/BUILD
@@ -44,6 +44,7 @@ py_test(
         requirement("opencensus-context"),
         requirement("opencensus-ext-azure"),
         requirement("azure-datalake-store"),
+        requirement("tenacity"),
     ],
 )
 
@@ -68,5 +69,6 @@ py_test(
         requirement("opencensus-context"),
         requirement("opencensus-ext-azure"),
         requirement("azure-datalake-store"),
+        requirement("tenacity"),
     ],
 )

--- a/requirements.txt
+++ b/requirements.txt
@@ -218,6 +218,7 @@ sphinxcontrib-websupport==1.2.4
 stack_data==0.5.1
 tabulate==0.8.10
 tblib==1.7.0
+tenacity==8.2.1
 tensorboard==2.10.1
 tensorboard-data-server==0.6.1
 tensorboard-plugin-wit==1.8.1

--- a/src/python/deepgnn/graph_engine/backends/snark/BUILD
+++ b/src/python/deepgnn/graph_engine/backends/snark/BUILD
@@ -34,6 +34,7 @@ py_test(
         requirement("azure-datalake-store"),
         requirement("networkx"),
         requirement("fsspec"),
+        requirement("tenacity"),
     ],
 )
 
@@ -52,5 +53,6 @@ py_test(
         requirement("opencensus-context"),
         requirement("azure-datalake-store"),
         requirement("opencensus-ext-azure"),
+        requirement("tenacity"),
     ],
 )

--- a/src/python/deepgnn/graph_engine/data/BUILD
+++ b/src/python/deepgnn/graph_engine/data/BUILD
@@ -40,6 +40,6 @@ py_test(
         requirement("scikit-learn"),
         requirement("networkx"),
         requirement("fsspec"),
-
+        requirement("tenacity"),
     ],
 )

--- a/src/python/deepgnn/graph_engine/snark/client.py
+++ b/src/python/deepgnn/graph_engine/snark/client.py
@@ -59,11 +59,11 @@ def _parse_grpc_options(options: List[Tuple[str, str]]) -> Dict:
                     "backoff_multiplier": backoff_multiplier,
                 }
             except Exception as err:
-                get_logger().info(
-                    f"Cannot parse the grpc_options, set the deafult values. {err}"
-                )
+                get_logger().warning(f"Cannot parse the grpc_options: {err}")
                 break
+
     # default options, delay in second
+    get_logger().warning("Setting default retry parameters to max_attempts=5, initial_backoff=2, max_backoff=10, backoff_multiplier=2")
     return {
         "max_attempts": 5,
         "initial_backoff": 2,
@@ -1040,8 +1040,7 @@ class DistributedGraph(MemoryGraph):
             # Keep an empty object to avoid ifs
             self.path = GraphPath("")
 
-        # Forcing retry on grpc calls
-        self.dist_mode = True
+        # Using grpc options on DistributedGraph API calls
         retry_ops = _parse_grpc_options(grpc_options)
         self._retryer = Retrying(
             stop=stop_after_attempt(retry_ops["max_attempts"]),

--- a/src/python/deepgnn/graph_engine/snark/client.py
+++ b/src/python/deepgnn/graph_engine/snark/client.py
@@ -63,7 +63,9 @@ def _parse_grpc_options(options: List[Tuple[str, str]]) -> Dict:
                 break
 
     # default options, delay in second
-    get_logger().warning("Setting default retry parameters to max_attempts=5, initial_backoff=2, max_backoff=10, backoff_multiplier=2")
+    get_logger().warning(
+        "Setting default retry parameters to max_attempts=5, initial_backoff=2, max_backoff=10, backoff_multiplier=2"
+    )
     return {
         "max_attempts": 5,
         "initial_backoff": 2,

--- a/src/python/deepgnn/graph_engine/snark/tests/BUILD
+++ b/src/python/deepgnn/graph_engine/snark/tests/BUILD
@@ -37,6 +37,7 @@ py_test(
         requirement("opencensus-context"),
         requirement("opencensus-ext-azure"),
         requirement("azure-datalake-store"),
+        requirement("tenacity"),
     ],
 )
 
@@ -61,6 +62,7 @@ py_test(
         requirement("opencensus-context"),
         requirement("opencensus-ext-azure"),
         requirement("azure-datalake-store"),
+        requirement("tenacity"),
     ],
 )
 
@@ -127,6 +129,7 @@ py_test(
         requirement("opencensus-ext-azure"),
         requirement("fsspec"),
         requirement("azure-datalake-store"),
+        requirement("tenacity"),
     ],
 )
 
@@ -148,6 +151,7 @@ py_test(
         requirement("opencensus-context"),
         requirement("opencensus-ext-azure"),
         requirement("azure-datalake-store"),
+        requirement("tenacity"),
     ],
 )
 
@@ -193,6 +197,7 @@ py_test(
         requirement("azure-datalake-store"),
         requirement("fsspec"),
         requirement("aiohttp"),
+        requirement("tenacity"),
     ],
 )
 
@@ -214,6 +219,7 @@ py_test(
         requirement("opencensus-ext-azure"),
         requirement("fsspec"),
         requirement("azure-datalake-store"),
+        requirement("tenacity"),
     ],
 )
 
@@ -235,6 +241,7 @@ py_test(
         requirement("opencensus-context"),
         requirement("opencensus-ext-azure"),
         requirement("azure-datalake-store"),
+        requirement("tenacity"),
     ],
 )
 
@@ -260,6 +267,7 @@ py_test(
         requirement("pytest"),
         requirement("scipy"),
         requirement("scikit-learn"),
+        requirement("tenacity"),
     ],
     target_compatible_with = ["@platforms//os:linux"],
 )

--- a/src/python/deepgnn/pytorch/common/BUILD
+++ b/src/python/deepgnn/pytorch/common/BUILD
@@ -43,6 +43,7 @@ py_test(
         requirement("opencensus-context"),
         requirement("opencensus-ext-azure"),
         requirement("azure-datalake-store"),
+        requirement("tenacity"),
     ],
 )
 
@@ -67,5 +68,6 @@ py_test(
         requirement("opencensus-context"),
         requirement("opencensus-ext-azure"),
         requirement("azure-datalake-store"),
+        requirement("tenacity"),
     ],
 )

--- a/src/python/deepgnn/pytorch/encoding/BUILD
+++ b/src/python/deepgnn/pytorch/encoding/BUILD
@@ -43,6 +43,7 @@ py_test(
         requirement("opencensus-context"),
         requirement("opencensus-ext-azure"),
         requirement("azure-datalake-store"),
+        requirement("tenacity"),
     ],
 )
 
@@ -66,5 +67,6 @@ py_test(
         requirement("opencensus-context"),
         requirement("opencensus-ext-azure"),
         requirement("azure-datalake-store"),
+        requirement("tenacity"),
     ],
 )

--- a/src/python/deepgnn/pytorch/training/BUILD
+++ b/src/python/deepgnn/pytorch/training/BUILD
@@ -46,6 +46,7 @@ py_test(
             requirement("opencensus-context"),
             requirement("opencensus-ext-azure"),
             requirement("azure-datalake-store"),
+            requirement("tenacity"),
         ],
         "@platforms//os:macos": [
             ":deepgnn_pytorch_training",
@@ -62,6 +63,7 @@ py_test(
             requirement("opencensus-context"),
             requirement("opencensus-ext-azure"),
             requirement("azure-datalake-store"),
+            requirement("tenacity"),
         ],
         "@platforms//os:windows": [
             ":deepgnn_pytorch_training",
@@ -77,6 +79,7 @@ py_test(
             requirement("opencensus-context"),
             requirement("opencensus-ext-azure"),
             requirement("azure-datalake-store"),
+            requirement("tenacity"),
         ],
     }),
 )

--- a/src/python/deepgnn/tf/common/BUILD
+++ b/src/python/deepgnn/tf/common/BUILD
@@ -71,6 +71,7 @@ py_test(
         requirement("opencensus-context"),
         requirement("opencensus-ext-azure"),
         requirement("azure-datalake-store"),
+        requirement("tenacity"),
     ],
 )
 
@@ -93,5 +94,6 @@ py_test(
         requirement("opencensus-context"),
         requirement("opencensus-ext-azure"),
         requirement("azure-datalake-store"),
+        requirement("tenacity"),
     ],
 )

--- a/src/python/deepgnn/tf/common/unittest/BUILD
+++ b/src/python/deepgnn/tf/common/unittest/BUILD
@@ -25,5 +25,6 @@ py_test(
         requirement("opencensus-context"),
         requirement("opencensus-ext-azure"),
         requirement("azure-datalake-store"),
+        requirement("tenacity"),
     ],
 )

--- a/src/python/setup.py
+++ b/src/python/setup.py
@@ -83,7 +83,7 @@ def graph_engine(version: str):
             "fsspec>=2021.8.1",
             "scikit-learn",
             "scipy",
-            "tenacity>=8"
+            "tenacity>=8",
         ],
         project_urls={
             "Source": "https://github.com/microsoft/DeepGNN",

--- a/src/python/setup.py
+++ b/src/python/setup.py
@@ -83,6 +83,7 @@ def graph_engine(version: str):
             "fsspec>=2021.8.1",
             "scikit-learn",
             "scipy",
+            "tenacity>=8"
         ],
         project_urls={
             "Source": "https://github.com/microsoft/DeepGNN",


### PR DESCRIPTION
- [x] Forked repo is synced with upstream -> github shows no code delta outside of the desired.
    https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork
- [x] Tests are passing? https://github.com/microsoft/DeepGNN/blob/main/CONTRIBUTING.md#run-tests
- [ ] Changelog and documentation updated.
- [ ] PR is labeled using the label menu on the right side.

Previous Behavior
----------------
Various connection issues can lead to unexpected code behavior #160 


New Behavior
----------------
The snark client will retry on failed queries using the already defined `grpc_options`.


Notes
----------------
This problem is occurring due to grpc design, where retry is not valid on [_committed RPCs_](https://github.com/grpc/proposal/blob/master/A6-client-retries.md#when-retries-are-valid). Current solution is not the most efficient way of solving it as it retry the whole query in case of any failure. The better way might be to handle failed connection inside `client.cc` to avoid redundant calls to healthy servers.
