### PR TITLE
Expose options of DistributedGraph to DistributedClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- All `DistributedGraph` config options (e.g. `grpc_options`, `num_threads`, ...) are exposed to `DistributedClient` and `BackendOptions`
+
 ## [0.1.58] - 2022-02-15
 
 ### Added

--- a/src/python/deepgnn/graph_engine/backends/options.py
+++ b/src/python/deepgnn/graph_engine/backends/options.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 """Options to initialize graph engine."""
 import argparse
-from typing import List
+from typing import List, Optional, Tuple
 from enum import Enum
 from deepgnn.graph_engine.snark.converter.options import ConverterOptions
 from deepgnn.graph_engine.snark.client import PartitionStorageType
@@ -43,6 +43,9 @@ class BackendOptions:
         self.storage_type = PartitionStorageType.memory
         self.config_path = ""
         self.stream = False
+        self.grpc_options: List[Tuple] = []
+        self.num_threads: Optional[int] = None
+        self.num_cq_per_thread: Optional[int] = None
 
         # sometimes user need to implement their own backend, using this custom
         # field, user can start graph engine using their own code.

--- a/src/python/deepgnn/graph_engine/backends/snark/client.py
+++ b/src/python/deepgnn/graph_engine/backends/snark/client.py
@@ -61,6 +61,9 @@ class SnarkDistributedBackend(GraphEngineBackend):
                     self.ssl_cert: Optional[str] = (
                         options.ssl_cert if options.enable_ssl else None
                     )
+                    self.grpc_options = options.grpc_options
+                    self.num_threads = options.num_threads
+                    self.num_cq_per_thread = options.num_cq_per_thread
                     self._client: Optional[DistributedClient] = None
 
                 @property
@@ -68,7 +71,11 @@ class SnarkDistributedBackend(GraphEngineBackend):
                     with self.lock:
                         if self._client is None:
                             self._client = DistributedClient(
-                                self.servers, self.ssl_cert
+                                self.servers,
+                                self.ssl_cert,
+                                grpc_options=self.grpc_options,
+                                num_threads=self.num_threads,
+                                num_cq_per_thread=self.num_cq_per_thread,
                             )
                     return self._client
 

--- a/src/python/deepgnn/graph_engine/snark/distributed.py
+++ b/src/python/deepgnn/graph_engine/snark/distributed.py
@@ -22,6 +22,8 @@ class Client(ge_snark.Client):
         servers: Union[str, List[str]],
         ssl_cert: Optional[str] = None,
         grpc_options: Optional[List[Tuple[str, str]]] = None,
+        num_threads: Optional[int] = None,
+        num_cq_per_thread: Optional[int] = None,
     ):
         """Init snark client to wrapper around ctypes API of distributed graph."""
         self.logger = get_logger()
@@ -31,7 +33,11 @@ class Client(ge_snark.Client):
         self._servers = servers
         self._ssl_cert = ssl_cert
         self.graph = client.DistributedGraph(
-            servers, ssl_cert, grpc_options=grpc_options
+            servers,
+            ssl_cert,
+            grpc_options=grpc_options,
+            num_threads=num_threads,
+            num_cq_per_thread=num_cq_per_thread,
         )
         self.node_samplers: Dict[str, client.NodeSampler] = {}
         self.edge_samplers: Dict[str, client.EdgeSampler] = {}


### PR DESCRIPTION
- [x] Forked repo is synced with upstream -> github shows no code delta outside of the desired.
    https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork
- [x] Tests are passing? https://github.com/microsoft/DeepGNN/blob/main/CONTRIBUTING.md#run-tests
- [ ] Changelog and documentation updated.
- [ ] PR is labeled using the label menu on the right side.

Previous Behavior
----------------
only `servers` and `ssl_cert` was configurable with `DistributedClient`.

New Behavior
----------------
User can pass `num_threads`, `num_cq_per_thread` and `grpc_options` to `DistributedClient`