### PR TITLE
Wait for all thread handlers to fill call data queues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10"]
-        os: ["ubuntu-22.04", "macos-11", "windows-2019"]
+        os: ["ubuntu-22.04", "macos-12", "windows-2022"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3.3.0
@@ -29,7 +29,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.10"]
-        os: ["ubuntu-22.04", "macos-11", "windows-2019"]
+        os: ["ubuntu-22.04", "macos-12", "windows-2022"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3.3.0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10"]
-        os: ["ubuntu-22.04", "macos-11", "windows-2019"]
+        os: ["ubuntu-22.04", "macos-12", "windows-2022"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3.3.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.10"]
-        os: ["ubuntu-22.04", "macos-11", "windows-2019"]
+        os: ["ubuntu-22.04", "macos-12", "windows-2022"]
     steps:
       - uses: actions/checkout@v3.3.0
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ["ubuntu-22.04", "macos-11", "windows-2019"]
+        os: ["ubuntu-22.04", "macos-12", "windows-2022"]
     steps:
       - uses: actions/checkout@v3.3.0
       - name: Set up Python 3.10

--- a/src/cc/lib/distributed/server.h
+++ b/src/cc/lib/distributed/server.h
@@ -4,6 +4,7 @@
 #ifndef SNARK_SERVER_H
 #define SNARK_SERVER_H
 
+#include <latch>
 #include <memory>
 #include <thread>
 
@@ -44,6 +45,8 @@ class GRPCServer final
     std::shared_ptr<snark::GraphSampler::Service> m_sampler_service_impl;
     std::unique_ptr<grpc::Server> m_server;
     std::vector<std::thread> m_runner_threads;
+    std::atomic<bool> m_shutdown;
+    std::latch m_latch;
 };
 } // namespace snark
 #endif // SNARK_SERVER_H


### PR DESCRIPTION
- [x] Forked repo is synced with upstream -> github shows no code delta outside of the desired.
    https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork
- [x] Tests are passing? https://github.com/microsoft/DeepGNN/blob/main/CONTRIBUTING.md#run-tests
- [x] Changelog and documentation updated.
- [x] PR is labeled using the label menu on the right side.

Previous Behavior
----------------
Distributed tests were flaky.

New Behavior
----------------
The reason for failures was call data objects were added to completion queues after a shutdown. One out of 4 threads in CI agents were stuck in initialization phase and when a shutdown was called, its completion queue was not yet initialized. Addition of new call data objects to a stopped server were causing assertion failures. A solution to this problem is to wait with a latch for all threads to be initialized and only then proceed to serving requests. However latch is available only in the latest versions of MacOS, which forces us also to update CI workflows.