### PR TITLE
Implement uniform sampling for temporal graphs and add timestamps to result tuples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.1.60] - 2022-04-18
 
 ### Added
+- Every sampling method returns created_at timestamps as the last argument.
+
+## [0.1.60] - 2022-04-18
+
+### Added
 - Breaking. Temporal graph support. Custom decoders must add 2 optional integers in returned tuple in  `decode` method, representing `created_at` and `removed_at` fields. Metadata file must have a `watermark` field.
 
 - Last N created neighbors sampling method for temporal graphs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.1.60] - 2022-04-18
 
 ### Added
-- Every sampling method returns created_at timestamps as the last argument.
+- Add `return_edge_created_ts` argument to neighbor sampling methods to return timestamps when edges connecting nodes were created.
+
+### Fixed
+- Uniform sampling works in temporal graphs.
 
 ## [0.1.60] - 2022-04-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.60] - 2022-04-18
-
 ### Added
 - Add `return_edge_created_ts` argument to neighbor sampling methods to return timestamps when edges connecting nodes were created.
 

--- a/examples/pytorch/knowledgegraph/model.py
+++ b/examples/pytorch/knowledgegraph/model.py
@@ -145,9 +145,8 @@ class KGEModel(BaseModel):
             node_ids = inputs[:, 0]
             edge_type = 0
 
-        neighbor_nodes, _, _, neighbor_counts = graph.neighbors(
-            node_ids, np.array([edge_type], dtype=np.int32)
-        )
+        nbs = graph.neighbors(node_ids, np.array([edge_type], dtype=np.int32))
+        neighbor_nodes, neighbor_counts = nbs[0], nbs[3]
 
         cur_pos = 0
         all_negative_list = []
@@ -194,10 +193,10 @@ class KGEModel(BaseModel):
                 pos_id = triple[0]
                 edge_type = 0
 
-            neighbor_nodes, _, _, _ = graph.neighbors(
+            neighbor_nodes = graph.neighbors(
                 np.array([pos_id], dtype=np.int64),
                 np.array([edge_type], dtype=np.int32),
-            )
+            )[0]
 
             if m == 0:
                 tmp = [

--- a/examples/tensorflow/sage/sage.py
+++ b/examples/tensorflow/sage/sage.py
@@ -63,13 +63,13 @@ class SAGEQuery:
             t = len(layer_infos) - k - 1
             cur_nodes = neighbor_list[k]
             support_size *= layer_infos[t].num_samples
-            neighbors, w, types, _ = graph.sample_neighbors(
+            neighbors = graph.sample_neighbors(
                 nodes=cur_nodes,
                 edge_types=layer_infos[t].neighbor_edge_types,
                 count=layer_infos[t].num_samples,
                 strategy=layer_infos[t].strategy,
                 default_node=-1,
-            )
+            )[0]
             neighbor_list.append(neighbors.reshape(-1))
             support_sizes.append(support_size)
         return neighbor_list, support_sizes

--- a/src/cc/lib/benchmark/neighbor_sampler_benchmark.cc
+++ b/src/cc/lib/benchmark/neighbor_sampler_benchmark.cc
@@ -193,7 +193,7 @@ static void BM_ONE_NODE_TYPE_WEIGHTED(benchmark::State &state)
         const size_t batch_size = state.range(0);
         std::vector<float> total_neighbor_weight(batch_size);
         s.SampleNeighbor(
-            ++seed, std::span(input_nodes).subspan(offset, batch_size), std::span(edge_types), {},
+            false, ++seed, std::span(input_nodes).subspan(offset, batch_size), std::span(edge_types), {},
             num_neighbors_to_sample, std::span(node_holder).subspan(0, num_neighbors_to_sample * batch_size),
             std::span(type_holder).subspan(0, num_neighbors_to_sample * batch_size),
             std::span(weight_holder).subspan(0, num_neighbors_to_sample * batch_size), std::span(total_neighbor_weight),

--- a/src/cc/lib/benchmark/neighbor_sampler_benchmark.cc
+++ b/src/cc/lib/benchmark/neighbor_sampler_benchmark.cc
@@ -185,18 +185,19 @@ static void BM_ONE_NODE_TYPE_WEIGHTED(benchmark::State &state)
     std::vector<float> weight_holder(max_count, -1);
     std::vector<snark::Type> type_holder(max_count, -1);
     std::vector<snark::NodeId> node_holder(max_count, -1);
+    std::vector<snark::Timestamp> ts_holder(max_count, -1);
     int64_t seed = 42;
     size_t offset = 0;
     for (auto _ : state)
     {
         const size_t batch_size = state.range(0);
         std::vector<float> total_neighbor_weight(batch_size);
-        s.SampleNeighbor(++seed, std::span(input_nodes).subspan(offset, batch_size), std::span(edge_types), {},
-                         num_neighbors_to_sample,
-                         std::span(node_holder).subspan(0, num_neighbors_to_sample * batch_size),
-                         std::span(type_holder).subspan(0, num_neighbors_to_sample * batch_size),
-                         std::span(weight_holder).subspan(0, num_neighbors_to_sample * batch_size),
-                         std::span(total_neighbor_weight), 0, 0, -1);
+        s.SampleNeighbor(
+            ++seed, std::span(input_nodes).subspan(offset, batch_size), std::span(edge_types), {},
+            num_neighbors_to_sample, std::span(node_holder).subspan(0, num_neighbors_to_sample * batch_size),
+            std::span(type_holder).subspan(0, num_neighbors_to_sample * batch_size),
+            std::span(weight_holder).subspan(0, num_neighbors_to_sample * batch_size), std::span(total_neighbor_weight),
+            std::span(ts_holder).subspan(0, num_neighbors_to_sample * batch_size), 0, 0, -1);
         offset += batch_size;
         if (offset + batch_size > max_count)
         {

--- a/src/cc/lib/distributed/client.cc
+++ b/src/cc/lib/distributed/client.cc
@@ -818,7 +818,7 @@ void GRPCClient::LastNCreated(std::span<const NodeId> input_node_ids, std::span<
 void GRPCClient::FullNeighbor(std::span<const NodeId> node_ids, std::span<const Type> edge_types,
                               std::span<const snark::Timestamp> timestamps, std::vector<NodeId> &output_nodes,
                               std::vector<Type> &output_types, std::vector<float> &output_weights,
-                              std::span<uint64_t> output_neighbor_counts)
+                              std::vector<Timestamp> &out_edge_created_ts, std::span<uint64_t> output_neighbor_counts)
 {
     GetNeighborsRequest request;
 
@@ -841,7 +841,7 @@ void GRPCClient::FullNeighbor(std::span<const NodeId> node_ids, std::span<const 
             m_engine_stubs[shard]->PrepareAsyncGetNeighbors(&call->context, request, NextCompletionQueue());
 
         call->callback = [&responses_left, &replies, &output_nodes, &output_types, &output_weights,
-                          &output_neighbor_counts, &reply_offsets]() {
+                          &output_neighbor_counts, &reply_offsets, &out_edge_created_ts]() {
             // Skip processing until all responses arrived. All responses are stored in the `replies` variable,
             // so we can safely return.
             if (responses_left.fetch_sub(1) > 1)
@@ -879,6 +879,10 @@ void GRPCClient::FullNeighbor(std::span<const NodeId> node_ids, std::span<const 
                     output_weights.insert(std::end(output_weights), edge_weights_start, edge_weights_start + count);
                     auto edge_types_start = reply.edge_types().begin() + offset;
                     output_types.insert(std::end(output_types), edge_types_start, edge_types_start + count);
+
+                    auto edge_creation_ts_start = reply.timestamps().begin() + offset;
+                    out_edge_created_ts.insert(std::end(out_edge_created_ts), edge_creation_ts_start,
+                                               edge_creation_ts_start + count);
                     reply_offsets[reply_index] += count;
                 }
             }
@@ -894,8 +898,9 @@ void GRPCClient::FullNeighbor(std::span<const NodeId> node_ids, std::span<const 
 void GRPCClient::WeightedSampleNeighbor(int64_t seed, std::span<const NodeId> node_ids,
                                         std::span<const Type> edge_types, std::span<const snark::Timestamp> timestamps,
                                         size_t count, std::span<NodeId> output_neighbors, std::span<Type> output_types,
-                                        std::span<float> output_weights, NodeId default_node_id, float default_weight,
-                                        Type default_edge_type)
+                                        std::span<float> output_weights,
+                                        std::span<snark::Timestamp> output_edge_created_ts, NodeId default_node_id,
+                                        float default_weight, Type default_edge_type)
 {
     snark::Xoroshiro128PlusGenerator engine(seed);
     boost::random::uniform_int_distribution<int64_t> subseed(std::numeric_limits<int64_t>::min(),
@@ -926,8 +931,9 @@ void GRPCClient::WeightedSampleNeighbor(int64_t seed, std::span<const NodeId> no
         auto response_reader =
             m_engine_stubs[shard]->PrepareAsyncWeightedSampleNeighbors(&call->context, request, NextCompletionQueue());
 
-        call->callback = [&reply = replies[shard], count, output_neighbors, output_types, output_weights, node_ids,
-                          &mtx, &engine, &shard_weights, default_node_id, default_weight, default_edge_type]() {
+        call->callback = [&reply = replies[shard], count, output_neighbors, output_types, output_weights,
+                          output_edge_created_ts, node_ids, &mtx, &engine, &shard_weights, default_node_id,
+                          default_weight, default_edge_type]() {
             if (reply.node_ids().empty())
             {
                 return;
@@ -936,11 +942,13 @@ void GRPCClient::WeightedSampleNeighbor(int64_t seed, std::span<const NodeId> no
             auto curr_nodes = std::begin(node_ids);
             auto curr_out_neighbor = std::begin(output_neighbors);
             auto curr_out_type = std::begin(output_types);
+            auto curr_out_ts = std::begin(output_edge_created_ts);
             auto curr_out_weight = std::begin(output_weights);
             auto curr_shard_weight = std::begin(shard_weights);
 
             auto curr_reply_neighbor = std::begin(reply.neighbor_ids());
             auto curr_reply_type = std::begin(reply.neighbor_types());
+            auto curr_reply_ts = std::begin(reply.timestamps());
             auto curr_reply_weight = std::begin(reply.neighbor_weights());
             auto curr_reply_shard_weight = std::begin(reply.shard_weights());
             boost::random::uniform_real_distribution<float> selector(0, 1);
@@ -960,6 +968,7 @@ void GRPCClient::WeightedSampleNeighbor(int64_t seed, std::span<const NodeId> no
                     curr_out_neighbor += count;
                     curr_out_weight += count;
                     curr_out_type += count;
+                    curr_out_ts += count;
                     ++curr_shard_weight;
                 }
 
@@ -972,10 +981,12 @@ void GRPCClient::WeightedSampleNeighbor(int64_t seed, std::span<const NodeId> no
                     curr_out_neighbor = std::fill_n(curr_out_neighbor, count, default_node_id);
                     curr_out_weight = std::fill_n(curr_out_weight, count, default_weight);
                     curr_out_type = std::fill_n(curr_out_type, count, default_edge_type);
+                    curr_out_ts = std::fill_n(curr_out_ts, count, PLACEHOLDER_TIMESTAMP);
 
                     curr_reply_neighbor += count;
                     curr_reply_type += count;
                     curr_reply_weight += count;
+                    curr_reply_ts += count;
                     ++curr_nodes;
                     continue;
                 }
@@ -990,8 +1001,10 @@ void GRPCClient::WeightedSampleNeighbor(int64_t seed, std::span<const NodeId> no
                         ++curr_reply_weight;
                         ++curr_reply_neighbor;
                         ++curr_reply_type;
+                        ++curr_reply_ts;
                         ++curr_out_neighbor;
                         ++curr_out_type;
+                        ++curr_out_ts;
                         ++curr_out_weight;
                         continue;
                     }
@@ -999,6 +1012,7 @@ void GRPCClient::WeightedSampleNeighbor(int64_t seed, std::span<const NodeId> no
                     *(curr_out_neighbor++) = *(curr_reply_neighbor++);
                     *(curr_out_type++) = *(curr_reply_type++);
                     *(curr_out_weight++) = *(curr_reply_weight++);
+                    *(curr_out_ts++) = *(curr_reply_ts++);
                 }
 
                 ++curr_reply_shard_weight;
@@ -1007,6 +1021,7 @@ void GRPCClient::WeightedSampleNeighbor(int64_t seed, std::span<const NodeId> no
             }
 
             assert(curr_reply_weight == std::end(reply.neighbor_weights()));
+            assert(curr_reply_ts == std::end(reply.timestamps()));
             assert(curr_reply_neighbor == std::end(reply.neighbor_ids()));
             assert(curr_reply_type == std::end(reply.neighbor_types()));
             assert(curr_reply_shard_weight == std::end(reply.shard_weights()));
@@ -1023,7 +1038,8 @@ void GRPCClient::WeightedSampleNeighbor(int64_t seed, std::span<const NodeId> no
 void GRPCClient::UniformSampleNeighbor(bool without_replacement, int64_t seed, std::span<const NodeId> node_ids,
                                        std::span<const Type> edge_types, std::span<const snark::Timestamp> timestamps,
                                        size_t count, std::span<NodeId> output_neighbors, std::span<Type> output_types,
-                                       NodeId default_node_id, Type default_type)
+                                       std::span<snark::Timestamp> output_edge_created_ts, NodeId default_node_id,
+                                       Type default_type)
 {
     snark::Xoroshiro128PlusGenerator engine(seed);
     boost::random::uniform_int_distribution<int64_t> subseed(std::numeric_limits<int64_t>::min(),
@@ -1053,8 +1069,8 @@ void GRPCClient::UniformSampleNeighbor(bool without_replacement, int64_t seed, s
 
         auto response_reader =
             m_engine_stubs[shard]->PrepareAsyncUniformSampleNeighbors(&call->context, request, NextCompletionQueue());
-        call->callback = [&reply = replies[shard], count, output_types, node_ids, &mtx, &engine, &shard_counts,
-                          output_neighbors, default_node_id, default_type]() {
+        call->callback = [&reply = replies[shard], count, output_types, output_edge_created_ts, node_ids, &mtx, &engine,
+                          &shard_counts, output_neighbors, default_node_id, default_type]() {
             if (reply.node_ids().empty())
             {
                 return;
@@ -1063,9 +1079,11 @@ void GRPCClient::UniformSampleNeighbor(bool without_replacement, int64_t seed, s
             auto curr_nodes = std::begin(node_ids);
             auto curr_out_neighbor = std::begin(output_neighbors);
             auto curr_out_type = std::begin(output_types);
+            auto curr_out_ts = std::begin(output_edge_created_ts);
             auto curr_shard_weight = std::begin(shard_counts);
             auto curr_reply_neighbor = std::begin(reply.neighbor_ids());
             auto curr_reply_type = std::begin(reply.neighbor_types());
+            auto curr_reply_ts = std::begin(reply.timestamps());
             auto curr_reply_shard_weight = std::begin(reply.shard_counts());
             boost::random::uniform_real_distribution<float> selector(0, 1);
 
@@ -1083,6 +1101,7 @@ void GRPCClient::UniformSampleNeighbor(bool without_replacement, int64_t seed, s
                 {
                     curr_out_neighbor += count;
                     curr_out_type += count;
+                    curr_out_ts += count;
                     ++curr_shard_weight;
                 }
 
@@ -1094,9 +1113,11 @@ void GRPCClient::UniformSampleNeighbor(bool without_replacement, int64_t seed, s
 
                     curr_out_neighbor = std::fill_n(curr_out_neighbor, count, default_node_id);
                     curr_out_type = std::fill_n(curr_out_type, count, default_type);
+                    curr_out_ts = std::fill_n(curr_out_ts, count, PLACEHOLDER_TIMESTAMP);
 
                     curr_reply_neighbor += count;
                     curr_reply_type += count;
+                    curr_reply_ts += count;
                     ++curr_nodes;
                     continue;
                 }
@@ -1110,13 +1131,16 @@ void GRPCClient::UniformSampleNeighbor(bool without_replacement, int64_t seed, s
                     {
                         ++curr_reply_neighbor;
                         ++curr_reply_type;
+                        ++curr_reply_ts;
                         ++curr_out_neighbor;
                         ++curr_out_type;
+                        ++curr_out_ts;
                         continue;
                     }
 
                     *(curr_out_neighbor++) = *(curr_reply_neighbor++);
                     *(curr_out_type++) = *(curr_reply_type++);
+                    *(curr_out_ts++) = *(curr_reply_ts++);
                 }
 
                 ++curr_reply_shard_weight;
@@ -1126,6 +1150,7 @@ void GRPCClient::UniformSampleNeighbor(bool without_replacement, int64_t seed, s
 
             assert(curr_reply_neighbor == std::end(reply.neighbor_ids()));
             assert(curr_reply_type == std::end(reply.neighbor_types()));
+            assert(curr_reply_ts == std::end(reply.timestamps()));
             assert(curr_reply_shard_weight == std::end(reply.shard_counts()));
         };
 

--- a/src/cc/lib/distributed/client.h
+++ b/src/cc/lib/distributed/client.h
@@ -59,18 +59,18 @@ class GRPCClient final
     void FullNeighbor(std::span<const NodeId> node_ids, std::span<const Type> edge_types,
                       std::span<const snark::Timestamp> timestamps, std::vector<NodeId> &output_nodes,
                       std::vector<Type> &output_types, std::vector<float> &output_weights,
-                      std::span<uint64_t> output_neighbor_counts);
+                      std::vector<Timestamp> &out_edge_created_ts, std::span<uint64_t> output_neighbor_counts);
 
     void WeightedSampleNeighbor(int64_t seed, std::span<const NodeId> node_ids, std::span<const Type> edge_types,
                                 std::span<const snark::Timestamp> timestamps, size_t count,
                                 std::span<NodeId> output_nodes, std::span<Type> output_types,
-                                std::span<float> output_weights, NodeId default_node_id, float default_weight,
-                                Type default_edge_type);
+                                std::span<float> output_weights, std::span<Timestamp> output_edge_created_ts,
+                                NodeId default_node_id, float default_weight, Type default_edge_type);
 
     void UniformSampleNeighbor(bool without_replacement, int64_t seed, std::span<const NodeId> node_ids,
                                std::span<const Type> edge_types, std::span<const snark::Timestamp> timestamps,
                                size_t count, std::span<NodeId> output_nodes, std::span<Type> output_types,
-                               NodeId default_node_id, Type default_type);
+                               std::span<Timestamp> output_edge_created_ts, NodeId default_node_id, Type default_type);
 
     void LastNCreated(std::span<const NodeId> input_node_ids, std::span<Type> input_edge_types,
                       std::span<const Timestamp> input_timestamps, size_t count, std::span<NodeId> output_neighbor_ids,

--- a/src/cc/lib/distributed/client.h
+++ b/src/cc/lib/distributed/client.h
@@ -56,27 +56,29 @@ class GRPCClient final
     void NeighborCount(std::span<const NodeId> node_ids, std::span<const Type> edge_types,
                        std::span<const snark::Timestamp> timestamps, std::span<uint64_t> output_neighbor_counts);
 
-    void FullNeighbor(std::span<const NodeId> node_ids, std::span<const Type> edge_types,
+    void FullNeighbor(bool return_edge_created_ts, std::span<const NodeId> node_ids, std::span<const Type> edge_types,
                       std::span<const snark::Timestamp> timestamps, std::vector<NodeId> &output_nodes,
                       std::vector<Type> &output_types, std::vector<float> &output_weights,
                       std::vector<Timestamp> &out_edge_created_ts, std::span<uint64_t> output_neighbor_counts);
 
-    void WeightedSampleNeighbor(int64_t seed, std::span<const NodeId> node_ids, std::span<const Type> edge_types,
-                                std::span<const snark::Timestamp> timestamps, size_t count,
-                                std::span<NodeId> output_nodes, std::span<Type> output_types,
+    void WeightedSampleNeighbor(bool return_edge_created_ts, int64_t seed, std::span<const NodeId> node_ids,
+                                std::span<const Type> edge_types, std::span<const snark::Timestamp> timestamps,
+                                size_t count, std::span<NodeId> output_nodes, std::span<Type> output_types,
                                 std::span<float> output_weights, std::span<Timestamp> output_edge_created_ts,
                                 NodeId default_node_id, float default_weight, Type default_edge_type);
 
-    void UniformSampleNeighbor(bool without_replacement, int64_t seed, std::span<const NodeId> node_ids,
-                               std::span<const Type> edge_types, std::span<const snark::Timestamp> timestamps,
-                               size_t count, std::span<NodeId> output_nodes, std::span<Type> output_types,
+    void UniformSampleNeighbor(bool without_replacement, bool return_edge_created_ts, int64_t seed,
+                               std::span<const NodeId> node_ids, std::span<const Type> edge_types,
+                               std::span<const snark::Timestamp> timestamps, size_t count,
+                               std::span<NodeId> output_nodes, std::span<Type> output_types,
                                std::span<Timestamp> output_edge_created_ts, NodeId default_node_id, Type default_type);
 
-    void LastNCreated(std::span<const NodeId> input_node_ids, std::span<Type> input_edge_types,
-                      std::span<const Timestamp> input_timestamps, size_t count, std::span<NodeId> output_neighbor_ids,
-                      std::span<Type> output_neighbor_types, std::span<float> neighbors_weights,
-                      std::span<Timestamp> output_timestamps, NodeId default_node_id, float default_weight,
-                      Type default_edge_type, Timestamp default_timestamp);
+    void LastNCreated(bool return_edge_created_ts, std::span<const NodeId> input_node_ids,
+                      std::span<Type> input_edge_types, std::span<const Timestamp> input_timestamps, size_t count,
+                      std::span<NodeId> output_neighbor_ids, std::span<Type> output_neighbor_types,
+                      std::span<float> neighbors_weights, std::span<Timestamp> output_timestamps,
+                      NodeId default_node_id, float default_weight, Type default_edge_type,
+                      Timestamp default_timestamp);
 
     uint64_t CreateSampler(bool is_edge, CreateSamplerRequest_Category category, std::span<Type> types);
 

--- a/src/cc/lib/distributed/graph_engine.cc
+++ b/src/cc/lib/distributed/graph_engine.cc
@@ -454,6 +454,9 @@ grpc::Status GraphEngineServiceImpl::GetNeighbors(::grpc::ServerContext *context
                                                   const snark::GetNeighborsRequest *request,
                                                   snark::GetNeighborsReply *response)
 {
+    // Client might request timestamps, but the shard doesn't have them. Return placeholders then.
+    const auto return_edge_created_ts = request->return_edge_created_ts();
+    const auto fill_edge_ts_by_partition = request->return_edge_created_ts() && m_metadata.m_watermark >= 0;
     const auto node_count = request->node_ids().size();
     response->mutable_neighbor_counts()->Resize(node_count, 0);
     auto input_edge_types = std::span(request->edge_types().data(), request->edge_types().size());
@@ -476,7 +479,7 @@ grpc::Status GraphEngineServiceImpl::GetNeighbors(::grpc::ServerContext *context
             {
                 response->mutable_neighbor_counts()->at(node_index) +=
                     m_partitions[m_partitions_indices[index]].FullNeighbor(
-                        m_internal_indices[index],
+                        fill_edge_ts_by_partition, m_internal_indices[index],
                         request->timestamps().empty()
                             ? std::nullopt
                             : std::optional<snark::Timestamp>(request->timestamps(node_index)),
@@ -486,15 +489,23 @@ grpc::Status GraphEngineServiceImpl::GetNeighbors(::grpc::ServerContext *context
                 response->mutable_edge_types()->Add(std::begin(output_neighbor_types), std::end(output_neighbor_types));
                 response->mutable_edge_weights()->Add(std::begin(output_neighbors_weights),
                                                       std::end(output_neighbors_weights));
-                response->mutable_timestamps()->Add(std::begin(output_edge_created_ts),
-                                                    std::end(output_edge_created_ts));
+                if (fill_edge_ts_by_partition)
+                {
+                    response->mutable_timestamps()->Add(std::begin(output_edge_created_ts),
+                                                        std::end(output_edge_created_ts));
+                    output_edge_created_ts.resize(0);
+                }
                 output_neighbor_ids.resize(0);
                 output_neighbor_types.resize(0);
                 output_neighbors_weights.resize(0);
-                output_edge_created_ts.resize(0);
             }
         }
     }
+    if (return_edge_created_ts && !fill_edge_ts_by_partition)
+    {
+        response->mutable_timestamps()->Resize(response->node_ids().size(), snark::PLACEHOLDER_TIMESTAMP);
+    }
+
     return grpc::Status::OK;
 }
 
@@ -502,6 +513,8 @@ grpc::Status GraphEngineServiceImpl::GetLastNCreatedNeighbors(::grpc::ServerCont
                                                               const snark::GetLastNCreatedNeighborsRequest *request,
                                                               snark::GetNeighborsReply *response)
 {
+    // Graph has to be temporal and we always return timestamps for client to merge data from multiple shards correctly.
+    assert(m_metadata.m_watermark >= 0);
     const auto node_count = request->node_ids().size();
     const auto count = size_t(request->count());
     const auto response_size = node_count * count;
@@ -515,7 +528,7 @@ grpc::Status GraphEngineServiceImpl::GetLastNCreatedNeighbors(::grpc::ServerCont
         std::span(response->mutable_edge_types()->mutable_data(), response->edge_types().size());
     response->mutable_edge_weights()->Resize(response_size, -1.f);
     auto output_weights = std::span(response->mutable_edge_weights()->mutable_data(), response->edge_weights().size());
-    response->mutable_timestamps()->Resize(response_size, -1);
+    response->mutable_timestamps()->Resize(response_size, snark::PLACEHOLDER_TIMESTAMP);
     auto output_timestamps = std::span(response->mutable_timestamps()->mutable_data(), response->timestamps().size());
     for (int node_index = 0; node_index < node_count; ++node_index)
     {
@@ -526,22 +539,24 @@ grpc::Status GraphEngineServiceImpl::GetLastNCreatedNeighbors(::grpc::ServerCont
         }
         else
         {
+            lastn_queue lastn;
             const auto index = internal_id->second;
             const size_t partition_count = m_counts[index];
             size_t found_neighbors = 0;
             for (size_t partition = 0; partition < partition_count; ++partition)
             {
                 const auto partition_nbs = m_partitions[m_partitions_indices[index + partition]].LastNCreatedNeighbors(
-                    m_internal_indices[index + partition], request->timestamps(node_index), input_edge_types, count,
-                    output_neighbor_ids.subspan(count * node_index, count),
+                    true, m_internal_indices[index + partition], request->timestamps(node_index), input_edge_types,
+                    count, output_neighbor_ids.subspan(count * node_index, count),
                     output_neighbor_types.subspan(count * node_index, count),
                     output_weights.subspan(count * node_index, count),
-                    output_timestamps.subspan(count * node_index, count), -1, -1, -1, -1);
+                    output_timestamps.subspan(count * node_index, count), lastn, -1, -1, -1, -1);
                 found_neighbors = std::max(found_neighbors, partition_nbs);
             }
             response->mutable_neighbor_counts()->Set(node_index, found_neighbors);
         }
     }
+
     return grpc::Status::OK;
 }
 
@@ -551,6 +566,9 @@ grpc::Status GraphEngineServiceImpl::WeightedSampleNeighbors(::grpc::ServerConte
 {
     assert(std::is_sorted(std::begin(request->edge_types()), std::end(request->edge_types())));
 
+    // Client might request timestamps, but the shard doesn't have them. Return placeholders then.
+    const auto return_edge_created_ts = request->return_edge_created_ts();
+    const auto fill_edge_ts_by_partition = return_edge_created_ts && m_metadata.m_watermark >= 0;
     size_t count = request->count();
     size_t nodes_found = 0;
     auto input_edge_types = std::span(request->edge_types().data(), request->edge_types().size());
@@ -574,11 +592,14 @@ grpc::Status GraphEngineServiceImpl::WeightedSampleNeighbors(::grpc::ServerConte
         response->mutable_neighbor_ids()->Resize(nodes_found * count, request->default_node_id());
         response->mutable_neighbor_types()->Resize(nodes_found * count, request->default_edge_type());
         response->mutable_neighbor_weights()->Resize(nodes_found * count, request->default_node_weight());
-        response->mutable_timestamps()->Resize(nodes_found * count, PLACEHOLDER_TIMESTAMP);
+        if (return_edge_created_ts)
+        {
+            response->mutable_timestamps()->Resize(nodes_found * count, PLACEHOLDER_TIMESTAMP);
+        }
         for (size_t partition = 0; partition < partition_count; ++partition)
         {
             m_partitions[m_partitions_indices[index + partition]].SampleNeighbor(
-                seed++, m_internal_indices[index + partition],
+                fill_edge_ts_by_partition, seed++, m_internal_indices[index + partition],
                 request->timestamps().empty() ? std::nullopt
                                               : std::optional<snark::Timestamp>(request->timestamps(node_index)),
                 input_edge_types, count, std::span(response->mutable_neighbor_ids()->mutable_data() + offset, count),
@@ -588,6 +609,12 @@ grpc::Status GraphEngineServiceImpl::WeightedSampleNeighbors(::grpc::ServerConte
                 request->default_node_id(), request->default_node_weight(), request->default_edge_type());
         }
     }
+    if (return_edge_created_ts && !fill_edge_ts_by_partition)
+    {
+        std::fill(std::begin(*response->mutable_timestamps()), std::end(*response->mutable_timestamps()),
+                  snark::PLACEHOLDER_TIMESTAMP);
+    }
+
     return grpc::Status::OK;
 }
 
@@ -597,6 +624,9 @@ grpc::Status GraphEngineServiceImpl::UniformSampleNeighbors(::grpc::ServerContex
 {
     assert(std::is_sorted(std::begin(request->edge_types()), std::end(request->edge_types())));
 
+    // Client might request timestamps, but the shard doesn't have them. Return placeholders then.
+    const auto return_edge_created_ts = request->return_edge_created_ts();
+    const auto fill_edge_ts_by_partition = return_edge_created_ts && m_metadata.m_watermark >= 0;
     size_t count = request->count();
     size_t nodes_found = 0;
     bool without_replacement = request->without_replacement();
@@ -624,19 +654,31 @@ grpc::Status GraphEngineServiceImpl::UniformSampleNeighbors(::grpc::ServerContex
         auto &last_shard_weight = response->mutable_shard_counts()->at(nodes_found - 1);
         response->mutable_neighbor_ids()->Resize(nodes_found * count, request->default_node_id());
         response->mutable_neighbor_types()->Resize(nodes_found * count, request->default_edge_type());
-        response->mutable_timestamps()->Resize(nodes_found * count, PLACEHOLDER_TIMESTAMP);
+        std::span<snark::Timestamp> response_ts;
+        if (return_edge_created_ts)
+        {
+            response->mutable_timestamps()->Resize(nodes_found * count, PLACEHOLDER_TIMESTAMP);
+            response_ts = std::span(response->mutable_timestamps()->mutable_data() + offset, count);
+        }
+
         for (size_t partition = 0; partition < partition_count; ++partition)
         {
             m_partitions[m_partitions_indices[index + partition]].UniformSampleNeighbor(
-                without_replacement, m_internal_indices[index + partition],
+                without_replacement, fill_edge_ts_by_partition, m_internal_indices[index + partition],
                 request->timestamps().empty() ? std::nullopt
                                               : std::optional<snark::Timestamp>(request->timestamps(node_index)),
                 input_edge_types, count, std::span(response->mutable_neighbor_ids()->mutable_data() + offset, count),
-                std::span(response->mutable_neighbor_types()->mutable_data() + offset, count),
-                std::span(response->mutable_timestamps()->mutable_data() + offset, count), last_shard_weight,
-                request->default_node_id(), request->default_edge_type(), reservoir, replacement_sampler);
+                std::span(response->mutable_neighbor_types()->mutable_data() + offset, count), response_ts,
+                last_shard_weight, request->default_node_id(), request->default_edge_type(), reservoir,
+                replacement_sampler);
         }
     }
+    if (return_edge_created_ts && !fill_edge_ts_by_partition)
+    {
+        std::fill(std::begin(*response->mutable_timestamps()), std::end(*response->mutable_timestamps()),
+                  snark::PLACEHOLDER_TIMESTAMP);
+    }
+
     return grpc::Status::OK;
 }
 

--- a/src/cc/lib/distributed/service.proto
+++ b/src/cc/lib/distributed/service.proto
@@ -106,7 +106,6 @@ message NodeFeaturesRequest {
   repeated int64 timestamps = 3;
 }
 
-
 message NodeFeaturesReply {
   // Keep bytes to simplify addition of new features later.
   bytes feature_values = 1;
@@ -164,6 +163,7 @@ message GetNeighborsRequest {
   repeated int64 node_ids = 1;
   repeated int32 edge_types = 2;
   repeated int64 timestamps = 3;
+  bool return_edge_created_ts = 4;
 }
 
 message GetNeighborsReply {
@@ -188,6 +188,7 @@ message WeightedSampleNeighborsRequest {
   int32 default_edge_type = 6;
   int32 count = 7;
   repeated int64 timestamps = 8;
+  bool return_edge_created_ts = 9;
 }
 
 message WeightedSampleNeighborsReply {
@@ -209,6 +210,7 @@ message UniformSampleNeighborsRequest {
   int32 count = 6;
   bool without_replacement = 7;
   repeated int64 timestamps = 8;
+  bool return_edge_created_ts = 9;
 }
 
 message UniformSampleNeighborsReply {

--- a/src/cc/lib/graph/BUILD
+++ b/src/cc/lib/graph/BUILD
@@ -12,6 +12,7 @@ cc_library(
         "partition.cc",
         "sampler.cc",
         "hdfs_wrap.cc",
+        "reservoir.cc",
     ],
     hdrs = [
         "graph.h",
@@ -23,6 +24,7 @@ cc_library(
         "hdfs_wrap.h",
         "types.h",
         "xoroshiro.h",
+        "reservoir.h",
     ],
     copts = CXX_OPTS,
     linkopts = select({

--- a/src/cc/lib/graph/graph.cc
+++ b/src/cc/lib/graph/graph.cc
@@ -386,13 +386,14 @@ void Graph::NeighborCount(std::span<const NodeId> input_node_ids, std::span<cons
     }
 }
 
-void Graph::FullNeighbor(std::span<const NodeId> input_node_ids, std::span<const Type> input_edge_types,
-                         std::span<const Timestamp> timestamps, std::vector<NodeId> &output_neighbor_ids,
-                         std::vector<Type> &output_neighbor_types, std::vector<float> &output_neighbors_weights,
-                         std::vector<Timestamp> &output_edge_created_ts,
+void Graph::FullNeighbor(bool return_edge_created_ts, std::span<const NodeId> input_node_ids,
+                         std::span<const Type> input_edge_types, std::span<const Timestamp> timestamps,
+                         std::vector<NodeId> &output_neighbor_ids, std::vector<Type> &output_neighbor_types,
+                         std::vector<float> &output_neighbors_weights, std::vector<Timestamp> &output_edge_created_ts,
                          std::span<uint64_t> output_neighbors_counts) const
 {
     std::fill(std::begin(output_neighbors_counts), std::end(output_neighbors_counts), 0);
+    const auto fill_edge_ts_by_partition = return_edge_created_ts && m_metadata.m_watermark >= 0;
     for (size_t node_index = 0; node_index < input_node_ids.size(); ++node_index)
     {
         auto internal_id = m_node_map.find(input_node_ids[node_index]);
@@ -407,21 +408,28 @@ void Graph::FullNeighbor(std::span<const NodeId> input_node_ids, std::span<const
             for (size_t partition = 0; partition < partition_count; ++partition, ++index)
             {
                 output_neighbors_counts[node_index] += m_partitions[m_partitions_indices[index]].FullNeighbor(
-                    m_internal_indices[index],
+                    fill_edge_ts_by_partition, m_internal_indices[index],
                     timestamps.empty() ? std::nullopt : std::optional<snark::Timestamp>{timestamps[node_index]},
                     input_edge_types, output_neighbor_ids, output_neighbor_types, output_neighbors_weights,
                     output_edge_created_ts);
             }
         }
     }
+
+    if (return_edge_created_ts && !fill_edge_ts_by_partition)
+    {
+        output_edge_created_ts.resize(output_neighbor_ids.size(), PLACEHOLDER_TIMESTAMP);
+    }
 }
 
-void Graph::SampleNeighbor(int64_t seed, std::span<const NodeId> input_node_ids, std::span<Type> input_edge_types,
-                           std::span<const Timestamp> timestamps, size_t count, std::span<NodeId> output_neighbor_ids,
-                           std::span<Type> output_neighbor_types, std::span<float> neighbors_weights,
-                           std::span<float> neighbors_total_weights, std::span<Timestamp> output_edge_created_ts,
-                           NodeId default_node_id, float default_weight, Type default_edge_type) const
+void Graph::SampleNeighbor(bool return_edge_created_ts, int64_t seed, std::span<const NodeId> input_node_ids,
+                           std::span<Type> input_edge_types, std::span<const Timestamp> timestamps, size_t count,
+                           std::span<NodeId> output_neighbor_ids, std::span<Type> output_neighbor_types,
+                           std::span<float> neighbors_weights, std::span<float> neighbors_total_weights,
+                           std::span<Timestamp> output_edge_created_ts, NodeId default_node_id, float default_weight,
+                           Type default_edge_type) const
 {
+    const auto fill_edge_ts_by_partition = return_edge_created_ts && m_metadata.m_watermark >= 0;
     if (!check_sorted_unique_types(input_edge_types.data(), input_edge_types.size()))
     {
         std::sort(std::begin(input_edge_types), std::end(input_edge_types));
@@ -437,7 +445,10 @@ void Graph::SampleNeighbor(int64_t seed, std::span<const NodeId> input_node_ids,
             std::fill_n(std::begin(output_neighbor_ids) + count * node_index, count, default_node_id);
             std::fill_n(std::begin(output_neighbor_types) + count * node_index, count, default_edge_type);
             std::fill_n(std::begin(neighbors_weights) + count * node_index, count, default_weight);
-            std::fill_n(std::begin(output_edge_created_ts) + count * node_index, count, PLACEHOLDER_TIMESTAMP);
+            if (return_edge_created_ts)
+            {
+                std::fill_n(std::begin(output_edge_created_ts) + count * node_index, count, PLACEHOLDER_TIMESTAMP);
+            }
         }
         else
         {
@@ -446,7 +457,7 @@ void Graph::SampleNeighbor(int64_t seed, std::span<const NodeId> input_node_ids,
             for (size_t partition = 0; partition < partition_count; ++partition)
             {
                 m_partitions[m_partitions_indices[index + partition]].SampleNeighbor(
-                    seed++, m_internal_indices[index + partition],
+                    fill_edge_ts_by_partition, seed++, m_internal_indices[index + partition],
                     timestamps.empty() ? std::nullopt : std::optional<snark::Timestamp>{timestamps[node_index]},
                     input_edge_types, count, output_neighbor_ids.subspan(count * node_index, count),
                     output_neighbor_types.subspan(count * node_index, count),
@@ -456,15 +467,21 @@ void Graph::SampleNeighbor(int64_t seed, std::span<const NodeId> input_node_ids,
             }
         }
     }
+    if (return_edge_created_ts && !fill_edge_ts_by_partition)
+    {
+        std::fill(std::begin(output_edge_created_ts), std::end(output_edge_created_ts), PLACEHOLDER_TIMESTAMP);
+    }
 }
 
-void Graph::UniformSampleNeighbor(bool without_replacement, int64_t seed, std::span<const NodeId> input_node_ids,
-                                  std::span<Type> input_edge_types, std::span<const Timestamp> timestamps, size_t count,
+void Graph::UniformSampleNeighbor(bool without_replacement, bool return_edge_created_ts, int64_t seed,
+                                  std::span<const NodeId> input_node_ids, std::span<Type> input_edge_types,
+                                  std::span<const Timestamp> timestamps, size_t count,
                                   std::span<NodeId> output_neighbor_ids, std::span<Type> output_neighbor_types,
                                   std::span<uint64_t> neighbors_total_count,
                                   std::span<Timestamp> output_edge_created_ts, NodeId default_node_id,
                                   Type default_edge_type) const
 {
+    const auto fill_edge_ts_by_partition = return_edge_created_ts && m_metadata.m_watermark >= 0;
     snark::Xoroshiro128PlusGenerator gen(seed);
     if (!check_sorted_unique_types(input_edge_types.data(), input_edge_types.size()))
     {
@@ -483,7 +500,10 @@ void Graph::UniformSampleNeighbor(bool without_replacement, int64_t seed, std::s
         {
             std::fill_n(std::begin(out_nb_ids), count, default_node_id);
             std::fill_n(std::begin(out_nb_types), count, default_edge_type);
-            std::fill_n(std::begin(out_nb_ts), count, PLACEHOLDER_TIMESTAMP);
+            if (return_edge_created_ts)
+            {
+                std::fill_n(std::begin(out_nb_ts), count, PLACEHOLDER_TIMESTAMP);
+            }
         }
         else
         {
@@ -493,7 +513,7 @@ void Graph::UniformSampleNeighbor(bool without_replacement, int64_t seed, std::s
             for (size_t partition = 0; partition < m_counts[index]; ++partition)
             {
                 m_partitions[m_partitions_indices[index + partition]].UniformSampleNeighbor(
-                    without_replacement, m_internal_indices[index + partition],
+                    without_replacement, fill_edge_ts_by_partition, m_internal_indices[index + partition],
                     timestamps.empty() ? std::nullopt : std::optional<snark::Timestamp>{timestamps[node_index]},
                     input_edge_types, count, out_nb_ids, out_nb_types, out_nb_ts, neighbors_total_count[node_index],
                     default_node_id, default_edge_type, sampler, replacement_sampler);
@@ -513,19 +533,27 @@ void Graph::UniformSampleNeighbor(bool without_replacement, int64_t seed, std::s
                           default_edge_type);
             }
 
-            std::fill(std::begin(out_nb_ts) + (timestamps.empty() ? 0 : neighbors_total_count[node_index]),
-                      std::end(out_nb_ts), snark::PLACEHOLDER_TIMESTAMP);
+            if (fill_edge_ts_by_partition)
+            {
+                std::fill(std::begin(out_nb_ts) + (timestamps.empty() ? 0 : neighbors_total_count[node_index]),
+                          std::end(out_nb_ts), snark::PLACEHOLDER_TIMESTAMP);
+            }
         }
+    }
+    if (return_edge_created_ts && !fill_edge_ts_by_partition)
+    {
+        std::fill(std::begin(output_edge_created_ts), std::end(output_edge_created_ts), PLACEHOLDER_TIMESTAMP);
     }
 }
 
-void Graph::LastNCreated(std::span<const NodeId> input_node_ids, std::span<Type> input_edge_types,
-                         std::span<const Timestamp> input_timestamps, size_t count,
+void Graph::LastNCreated(bool return_edge_created_ts, std::span<const NodeId> input_node_ids,
+                         std::span<Type> input_edge_types, std::span<const Timestamp> input_timestamps, size_t count,
                          std::span<NodeId> output_neighbor_ids, std::span<Type> output_neighbor_types,
                          std::span<float> output_weights, std::span<Timestamp> output_timestamps,
                          NodeId default_node_id, float default_weight, Type default_edge_type,
                          Timestamp default_timestamp) const
 {
+    const auto fill_edge_ts_by_partition = return_edge_created_ts && m_metadata.m_watermark >= 0;
     if (!check_sorted_unique_types(input_edge_types.data(), input_edge_types.size()))
     {
         std::sort(std::begin(input_edge_types), std::end(input_edge_types));
@@ -533,8 +561,12 @@ void Graph::LastNCreated(std::span<const NodeId> input_node_ids, std::span<Type>
         input_edge_types = input_edge_types.subspan(0, last - std::begin(input_edge_types));
     }
 
-    // backfill global timestamps with minimal values for easier management in a priority queue later.
-    std::fill(std::begin(output_timestamps), std::end(output_timestamps), -1);
+    if (return_edge_created_ts)
+    {
+        // backfill global timestamps with minimal values for easier management in a priority queue later.
+        std::fill(std::begin(output_timestamps), std::end(output_timestamps), -1);
+    }
+
     for (size_t node_index = 0; node_index < input_node_ids.size(); ++node_index)
     {
         auto internal_id = m_node_map.find(input_node_ids[node_index]);
@@ -543,20 +575,31 @@ void Graph::LastNCreated(std::span<const NodeId> input_node_ids, std::span<Type>
             std::fill_n(std::begin(output_neighbor_ids) + count * node_index, count, default_node_id);
             std::fill_n(std::begin(output_neighbor_types) + count * node_index, count, default_edge_type);
             std::fill_n(std::begin(output_weights) + count * node_index, count, default_weight);
+            if (return_edge_created_ts)
+            {
+                std::fill_n(std::begin(output_timestamps) + count * node_index, count, default_timestamp);
+            }
         }
         else
         {
+            lastn_queue lastn;
             const auto index = internal_id->second;
             size_t found_neighbors = 0;
+
+            // Take care of debug builds assertion on span size.
+            auto out_ts = output_timestamps;
+            if (return_edge_created_ts)
+            {
+                out_ts = output_timestamps.subspan(count * node_index, count);
+            }
             for (size_t partition = 0; partition < m_counts[index]; ++partition)
             {
                 const auto partition_nbs = m_partitions[m_partitions_indices[index + partition]].LastNCreatedNeighbors(
-                    m_internal_indices[index + partition], input_timestamps[node_index], input_edge_types, count,
-                    output_neighbor_ids.subspan(count * node_index, count),
+                    fill_edge_ts_by_partition, m_internal_indices[index + partition], input_timestamps[node_index],
+                    input_edge_types, count, output_neighbor_ids.subspan(count * node_index, count),
                     output_neighbor_types.subspan(count * node_index, count),
-                    output_weights.subspan(count * node_index, count),
-                    output_timestamps.subspan(count * node_index, count), default_node_id, default_edge_type,
-                    default_weight, default_timestamp);
+                    output_weights.subspan(count * node_index, count), out_ts, lastn, default_node_id,
+                    default_edge_type, default_weight, default_timestamp);
                 found_neighbors = std::max(found_neighbors, partition_nbs);
             }
             if (found_neighbors < count)
@@ -566,9 +609,16 @@ void Graph::LastNCreated(std::span<const NodeId> input_node_ids, std::span<Type>
                 std::fill_n(std::begin(output_neighbor_ids) + offset, backfill_count, default_node_id);
                 std::fill_n(std::begin(output_neighbor_types) + offset, backfill_count, default_edge_type);
                 std::fill_n(std::begin(output_weights) + offset, backfill_count, default_weight);
-                std::fill_n(std::begin(output_timestamps) + offset, backfill_count, default_timestamp);
+                if (return_edge_created_ts)
+                {
+                    std::fill_n(std::begin(output_timestamps) + offset, backfill_count, default_timestamp);
+                }
             }
         }
+    }
+    if (return_edge_created_ts && !fill_edge_ts_by_partition)
+    {
+        std::fill(std::begin(output_timestamps), std::end(output_timestamps), default_timestamp);
     }
 }
 

--- a/src/cc/lib/graph/graph.h
+++ b/src/cc/lib/graph/graph.h
@@ -61,19 +61,20 @@ class Graph
     void FullNeighbor(std::span<const NodeId> input_node_ids, std::span<const Type> input_edge_types,
                       std::span<const Timestamp> timestamps, std::vector<NodeId> &output_neighbor_ids,
                       std::vector<Type> &output_neighbor_types, std::vector<float> &output_neighbors_weights,
+                      std::vector<Timestamp> &output_edge_created_ts,
                       std::span<uint64_t> output_neighbors_counts) const;
 
     void SampleNeighbor(int64_t seed, std::span<const NodeId> input_node_ids, std::span<Type> input_edge_types,
                         std::span<const Timestamp> timestamps, size_t count, std::span<NodeId> output_neighbor_ids,
                         std::span<Type> output_neighbor_types, std::span<float> neighbors_weights,
-                        std::span<float> neighbors_total_weights, NodeId default_node_id, float default_weight,
-                        Type default_edge_type) const;
+                        std::span<float> neighbors_total_weights, std::span<Timestamp> output_edge_created_ts,
+                        NodeId default_node_id, float default_weight, Type default_edge_type) const;
 
     void UniformSampleNeighbor(bool without_replacement, int64_t seed, std::span<const NodeId> input_node_ids,
                                std::span<Type> input_edge_types, std::span<const Timestamp> timestamps, size_t count,
                                std::span<NodeId> output_neighbor_ids, std::span<Type> output_neighbor_types,
-                               std::span<uint64_t> neighbors_total_count, NodeId default_node_id,
-                               Type default_edge_type) const;
+                               std::span<uint64_t> neighbors_total_count, std::span<Timestamp> output_edge_created_ts,
+                               NodeId default_node_id, Type default_edge_type) const;
 
     void LastNCreated(std::span<const NodeId> input_node_ids, std::span<Type> input_edge_types,
                       std::span<const Timestamp> input_timestamps, size_t count, std::span<NodeId> output_neighbor_ids,

--- a/src/cc/lib/graph/graph.h
+++ b/src/cc/lib/graph/graph.h
@@ -58,29 +58,32 @@ class Graph
     void NeighborCount(std::span<const NodeId> input_node_ids, std::span<const Type> input_edge_types,
                        std::span<const Timestamp> timestamps, std::span<uint64_t> output_neighbors_counts) const;
 
-    void FullNeighbor(std::span<const NodeId> input_node_ids, std::span<const Type> input_edge_types,
-                      std::span<const Timestamp> timestamps, std::vector<NodeId> &output_neighbor_ids,
-                      std::vector<Type> &output_neighbor_types, std::vector<float> &output_neighbors_weights,
-                      std::vector<Timestamp> &output_edge_created_ts,
+    void FullNeighbor(bool return_edge_created_ts, std::span<const NodeId> input_node_ids,
+                      std::span<const Type> input_edge_types, std::span<const Timestamp> timestamps,
+                      std::vector<NodeId> &output_neighbor_ids, std::vector<Type> &output_neighbor_types,
+                      std::vector<float> &output_neighbors_weights, std::vector<Timestamp> &output_edge_created_ts,
                       std::span<uint64_t> output_neighbors_counts) const;
 
-    void SampleNeighbor(int64_t seed, std::span<const NodeId> input_node_ids, std::span<Type> input_edge_types,
-                        std::span<const Timestamp> timestamps, size_t count, std::span<NodeId> output_neighbor_ids,
-                        std::span<Type> output_neighbor_types, std::span<float> neighbors_weights,
-                        std::span<float> neighbors_total_weights, std::span<Timestamp> output_edge_created_ts,
-                        NodeId default_node_id, float default_weight, Type default_edge_type) const;
+    void SampleNeighbor(bool return_edge_created_ts, int64_t seed, std::span<const NodeId> input_node_ids,
+                        std::span<Type> input_edge_types, std::span<const Timestamp> timestamps, size_t count,
+                        std::span<NodeId> output_neighbor_ids, std::span<Type> output_neighbor_types,
+                        std::span<float> neighbors_weights, std::span<float> neighbors_total_weights,
+                        std::span<Timestamp> output_edge_created_ts, NodeId default_node_id, float default_weight,
+                        Type default_edge_type) const;
 
-    void UniformSampleNeighbor(bool without_replacement, int64_t seed, std::span<const NodeId> input_node_ids,
-                               std::span<Type> input_edge_types, std::span<const Timestamp> timestamps, size_t count,
+    void UniformSampleNeighbor(bool without_replacement, bool return_edge_created_ts, int64_t seed,
+                               std::span<const NodeId> input_node_ids, std::span<Type> input_edge_types,
+                               std::span<const Timestamp> timestamps, size_t count,
                                std::span<NodeId> output_neighbor_ids, std::span<Type> output_neighbor_types,
                                std::span<uint64_t> neighbors_total_count, std::span<Timestamp> output_edge_created_ts,
                                NodeId default_node_id, Type default_edge_type) const;
 
-    void LastNCreated(std::span<const NodeId> input_node_ids, std::span<Type> input_edge_types,
-                      std::span<const Timestamp> input_timestamps, size_t count, std::span<NodeId> output_neighbor_ids,
-                      std::span<Type> output_neighbor_types, std::span<float> neighbors_weights,
-                      std::span<Timestamp> output_timestamps, NodeId default_node_id, float default_weight,
-                      Type default_edge_type, Timestamp default_timestamp) const;
+    void LastNCreated(bool return_edge_created_ts, std::span<const NodeId> input_node_ids,
+                      std::span<Type> input_edge_types, std::span<const Timestamp> input_timestamps, size_t count,
+                      std::span<NodeId> output_neighbor_ids, std::span<Type> output_neighbor_types,
+                      std::span<float> neighbors_weights, std::span<Timestamp> output_timestamps,
+                      NodeId default_node_id, float default_weight, Type default_edge_type,
+                      Timestamp default_timestamp) const;
 
     Metadata GetMetadata() const;
 

--- a/src/cc/lib/graph/partition.cc
+++ b/src/cc/lib/graph/partition.cc
@@ -770,13 +770,13 @@ size_t Partition::NeighborCount(uint64_t internal_id, std::optional<Timestamp> n
 
 size_t Partition::FullNeighbor(uint64_t internal_id, std::optional<Timestamp> node_ts, std::span<const Type> edge_types,
                                std::vector<NodeId> &out_neighbors_ids, std::vector<Type> &out_edge_types,
-                               std::vector<float> &out_edge_weights) const
+                               std::vector<float> &out_edge_weights, std::vector<Timestamp> &out_edge_created_ts) const
 {
     if (node_ts)
     {
         size_t count = 0;
         auto lambda = [&count, node_ts = node_ts.value(), &ts = m_edge_timestamps, &out_neighbors_ids, &out_edge_types,
-                       &out_edge_weights, this](const auto start, const auto last, const auto i) {
+                       &out_edge_weights, &out_edge_created_ts, this](const auto start, const auto last, const auto i) {
             for (size_t curr_ts = start; curr_ts < last; ++curr_ts)
             {
                 if (ts[curr_ts].first <= node_ts && (ts[curr_ts].second > node_ts || ts[curr_ts].second == -1))
@@ -786,6 +786,7 @@ size_t Partition::FullNeighbor(uint64_t internal_id, std::optional<Timestamp> no
                                                       ? m_edge_weights[curr_ts] - m_edge_weights[curr_ts - 1]
                                                       : m_edge_weights[start]);
                     out_edge_types.emplace_back(m_edge_types[i]);
+                    out_edge_created_ts.emplace_back(ts[curr_ts].first);
                     ++count;
                 }
             }
@@ -796,13 +797,15 @@ size_t Partition::FullNeighbor(uint64_t internal_id, std::optional<Timestamp> no
         return count;
     }
 
-    auto lambda = [&out_neighbors_ids, &out_edge_types, &out_edge_weights, this](auto start, auto last, int i) {
+    auto lambda = [&out_neighbors_ids, &out_edge_types, &out_edge_weights, &out_edge_created_ts,
+                   this](auto start, auto last, int i) {
         // m_edge_destination[last-1]+1 - take the last element and then advance the pointer
         // to imitate std::end, otherwise we'll have an out of range exception.
         out_neighbors_ids.insert(std::end(out_neighbors_ids), &m_edge_destination[start],
                                  &m_edge_destination[last - 1] + 1);
         auto original_type_size = out_edge_types.size();
         out_edge_types.resize(original_type_size + last - start, m_edge_types[i]);
+        out_edge_created_ts.resize(original_type_size + last - start, snark::PLACEHOLDER_TIMESTAMP);
         out_edge_weights.reserve(out_edge_weights.size() + last - start);
         for (size_t index = start; index < last; ++index)
         {
@@ -1081,8 +1084,9 @@ void Partition::GetEdgeStringFeature(uint64_t internal_src_node_id, NodeId input
 
 void Partition::SampleNeighbor(int64_t seed, uint64_t internal_node_id, std::optional<Timestamp> node_ts,
                                std::span<const Type> in_edge_types, uint64_t count, std::span<NodeId> out_nodes,
-                               std::span<Type> out_types, std::span<float> out_weights, float &out_partition,
-                               NodeId default_node_id, float default_weight, Type default_edge_type) const
+                               std::span<Type> out_types, std::span<float> out_weights,
+                               std::span<Timestamp> out_edge_created_ts, float &out_partition, NodeId default_node_id,
+                               float default_weight, Type default_edge_type) const
 {
     auto pos = 0;
     snark::Xoroshiro128PlusGenerator gen(seed);
@@ -1099,6 +1103,7 @@ void Partition::SampleNeighbor(int64_t seed, uint64_t internal_node_id, std::opt
             std::fill_n(std::begin(out_nodes) + pos, count, default_node_id);
             std::fill_n(std::begin(out_types) + pos, count, default_edge_type);
             std::fill_n(std::begin(out_weights) + pos, count, default_weight);
+            std::fill_n(std::begin(out_edge_created_ts) + pos, count, PLACEHOLDER_TIMESTAMP);
         }
 
         return;
@@ -1169,6 +1174,7 @@ void Partition::SampleNeighbor(int64_t seed, uint64_t internal_node_id, std::opt
             std::fill_n(std::begin(out_nodes) + pos, count, default_node_id);
             std::fill_n(std::begin(out_types) + pos, count, default_edge_type);
             std::fill_n(std::begin(out_weights) + pos, count, default_weight);
+            std::fill_n(std::begin(out_edge_created_ts) + pos, count, PLACEHOLDER_TIMESTAMP);
         }
 
         pos += count;
@@ -1251,6 +1257,7 @@ void Partition::SampleNeighbor(int64_t seed, uint64_t internal_node_id, std::opt
                         size_t nb_offset = std::distance(fst_nb, nb_pos);
                         out_nodes[pos] = m_edge_destination[local_offset + nb_offset];
                         out_types[pos] = m_edge_types[i];
+                        out_edge_created_ts[pos] = m_edge_timestamps[local_offset + nb_offset].first;
                         out_weights[pos] = (nb_offset == 0 && local_offset == first)
                                                ? m_edge_weights[local_offset]
                                                : m_edge_weights[local_offset + nb_offset] -
@@ -1292,6 +1299,7 @@ void Partition::SampleNeighbor(int64_t seed, uint64_t internal_node_id, std::opt
                     size_t nb_offset = std::distance(fst_nb, nb_pos);
                     out_nodes[pos] = m_edge_destination[first + nb_offset];
                     out_types[pos] = m_edge_types[i];
+                    out_edge_created_ts[pos] = PLACEHOLDER_TIMESTAMP;
                     out_weights[pos] = nb_offset == 0
                                            ? m_edge_weights[first]
                                            : m_edge_weights[first + nb_offset] - m_edge_weights[first + nb_offset - 1];
@@ -1305,21 +1313,24 @@ void Partition::SampleNeighbor(int64_t seed, uint64_t internal_node_id, std::opt
 }
 
 // in_edge_types has to have types in strictly increasing order.
-void Partition::UniformSampleNeighbor(bool without_replacement, int64_t seed, uint64_t internal_node_id,
+void Partition::UniformSampleNeighbor(bool without_replacement, uint64_t internal_node_id,
                                       std::optional<Timestamp> node_ts, std::span<const Type> in_edge_types,
                                       uint64_t count, std::span<NodeId> out_nodes, std::span<Type> out_types,
-                                      uint64_t &out_partition_count, NodeId default_node_id,
-                                      Type default_edge_type) const
+                                      std::span<Timestamp> out_edge_created_ts, uint64_t &out_partition_count,
+                                      NodeId default_node_id, Type default_edge_type, AlgorithmL &sampler,
+                                      WithReplacement &replacement_sampler) const
 {
     if (without_replacement)
     {
-        UniformSampleNeighborWithoutReplacement(seed, internal_node_id, node_ts, in_edge_types, count, out_nodes,
-                                                out_types, out_partition_count, default_node_id, default_edge_type);
+        UniformSampleNeighborWithoutReplacement(internal_node_id, node_ts, in_edge_types, count, out_nodes, out_types,
+                                                out_edge_created_ts, out_partition_count, default_node_id,
+                                                default_edge_type, sampler);
     }
     else
     {
-        UniformSampleNeighborWithReplacement(seed, internal_node_id, node_ts, in_edge_types, count, out_nodes,
-                                             out_types, out_partition_count, default_node_id, default_edge_type);
+        UniformSampleNeighborWithReplacement(internal_node_id, node_ts, in_edge_types, count, out_nodes, out_types,
+                                             out_edge_created_ts, out_partition_count, default_node_id,
+                                             default_edge_type, replacement_sampler);
     }
 }
 
@@ -1350,21 +1361,13 @@ bool advance_edge_types(size_t &in_edge_type_index, size_t &neighbor_type_index,
     return neighbor_types[neighbor_type_index] == in_edge_types[in_edge_type_index];
 }
 
-void Partition::UniformSampleNeighborWithReplacement(int64_t seed, uint64_t internal_id,
-                                                     std::optional<Timestamp> node_ts,
+void Partition::UniformSampleNeighborWithReplacement(uint64_t internal_id, std::optional<Timestamp> node_ts,
                                                      std::span<const Type> in_edge_types, uint64_t count,
                                                      std::span<NodeId> out_nodes, std::span<Type> out_types,
+                                                     std::span<Timestamp> out_edge_created_ts,
                                                      uint64_t &out_partition_count, NodeId default_node_id,
-                                                     Type default_edge_type) const
+                                                     Type default_edge_type, WithReplacement &replacement_sampler) const
 {
-    assert(!node_ts.has_value());
-
-    size_t pos = 0;
-    // It is important to use a good generator, because we use it to pick a number and merge results from multiple
-    // partitions. E.g. rand_48 engine will produce correlated samples.
-    snark::Xoroshiro128PlusGenerator gen(seed);
-    boost::random::uniform_real_distribution<float> toss(0, 1);
-
     const auto offset = m_neighbors_index[internal_id];
     const auto nb_count = m_neighbors_index[internal_id + 1] - offset;
 
@@ -1377,184 +1380,78 @@ void Partition::UniformSampleNeighborWithReplacement(int64_t seed, uint64_t inte
             continue;
         }
 
-        const auto curr_weight = m_edge_type_offset[neighbor_type_index + 1] - m_edge_type_offset[neighbor_type_index];
-        out_partition_count += curr_weight;
-        // Probabilities to select correct types will converge to right values:
-        // E.g. we have 3 neighbor types with 5, 9 and 11 elements, then probability
-        // to the first neighbor to have type 0 is 1 *(5/14) *(14/25) = 5/25
-        const auto merge_rate = float(curr_weight) / out_partition_count;
-        for (size_t nb = 0; nb < count; ++nb)
+        if (node_ts.has_value() && !m_edge_timestamps.empty())
         {
-            if (merge_rate == 1.0f || toss(gen) < merge_rate)
+            auto first = m_edge_type_offset[neighbor_type_index];
+            auto last = m_edge_type_offset[neighbor_type_index + 1] - 1;
+            ++last;
+            auto timestamp_span = std::span(m_edge_timestamps).subspan(first, last - first);
+            auto global_offset = first;
+            for (auto it = find_start(timestamp_span, node_ts.value());
+                 it != std::end(timestamp_span) && !(it->second == -1 && it->first > node_ts.value());
+                 it = find_start(timestamp_span, node_ts.value()))
             {
-                size_t pick = toss(gen) * curr_weight;
-                out_nodes[pos + nb] = m_edge_destination[m_edge_type_offset[neighbor_type_index] + pick];
-                out_types[pos + nb] = m_edge_types[neighbor_type_index];
+                const size_t it_dist = it - std::begin(timestamp_span);
+                const auto it_subspan = timestamp_span.subspan(it_dist);
+                auto lst = find_last(it_subspan, node_ts.value());
+                auto stream = it_subspan.subspan(0, lst - std::begin(it_subspan));
+                const size_t local_offset = global_offset + it_dist;
+
+                const auto curr_weight = stream.size();
+                out_partition_count += curr_weight;
+                auto ts_span = std::span(m_edge_timestamps).subspan(local_offset, curr_weight);
+                auto dst_span = std::span(m_edge_destination).subspan(local_offset, curr_weight);
+                replacement_sampler.add(curr_weight, [out_nodes, out_types, out_edge_created_ts,
+                                                      tp = m_edge_types[neighbor_type_index], ts_span, dst_span,
+                                                      this](size_t pick, size_t offset) {
+                    out_nodes[pick] = dst_span[offset];
+                    out_types[pick] = tp;
+                    out_edge_created_ts[pick] =
+                        m_edge_timestamps.empty() ? PLACEHOLDER_TIMESTAMP : ts_span[offset].first;
+                });
+
+                if (lst ==
+                    std::begin(it_subspan)) // cheking if positions are the same (lst == it) for different iterators.
+                {
+                    ++lst;
+                }
+                const auto local_pos =
+                    size_t((lst - std::begin(it_subspan)) + it_dist); // equivavlent of lst - std::begin(timestamp_span)
+                global_offset += local_pos;
+                timestamp_span = timestamp_span.subspan(local_pos);
             }
-        }
-    }
-
-    if (out_partition_count == 0)
-    {
-        std::fill_n(std::begin(out_nodes) + pos, count, default_node_id);
-        std::fill_n(std::begin(out_types) + pos, count, default_edge_type);
-    }
-
-    pos += count;
-}
-
-// Sample min(partition_weight, count) neighbors from a range (0..partition_weight) using reservoir sampling
-// and store indices in the `interim_neighbors`.
-void contiguous_uniform_sample_helper(size_t partition_weight, uint64_t count, std::vector<size_t> &interim_neighbors,
-                                      boost::random::uniform_real_distribution<double> &toss,
-                                      snark::Xoroshiro128PlusGenerator &gen)
-{
-    if (partition_weight <= count)
-    {
-        size_t start = 0;
-        std::generate_n(std::back_inserter(interim_neighbors), partition_weight, [&start]() {
-            const auto result = start;
-            ++start;
-            return result;
-        });
-        return;
-    }
-
-    for (size_t node = 0; node < count; ++node)
-    {
-        interim_neighbors.emplace_back(node);
-    }
-
-    float w = std::exp(std::log(toss(gen)) / count);
-    size_t i = count - 1;
-    while (i < partition_weight)
-    {
-        i += std::floor(std::log(toss(gen)) / std::log(1 - w)) + 1;
-        if (i < partition_weight)
-        {
-            const size_t pick = toss(gen) * count;
-            interim_neighbors[pick] = i;
-            w = w * std::exp(std::log(toss(gen)) / count);
-        }
-    }
-}
-
-// We can't use bernoulli sampling here, because the total number of actual neighbors in each list might be less
-// then `count` and we should rather do a direct sampling from both lists and track their overall length.
-// E.g. [1, 2, default, default, default] merged with [3,4, default, default, default] should be [1, 2, 3, 4,
-// default], rather than something like [1, 4, default, default, default].
-// Merge procedure is following:
-// 1. Pick a list with a probability proportional to the length of this list(without default elements).
-// 2. Randomly pick an element from the list and put it in the result.
-// 3. To make sure there are no repeating elements(without replacement), put selected element in the head of the
-// list and track the tail for selection.
-// 4. Assign the result array weight equal to the sum of lengths of original lists to make sure later merge will be
-// proportional. To show this procedure is not biased, lets merge lists [1,2,3, default] and [4, 5, 6, 7] into one
-// list with 4 elements. Probability that element 1 will be selected first is (3/7)*(1/3) = 1/7, same as element 5:
-// (4/7) * (1/4) = 1/7
-void Partition::UniformSampleMergeWithoutReplacement(
-    uint64_t count, std::vector<NodeId> &left_neighbors, std::vector<Type> &left_types, uint64_t left_weight,
-    std::vector<size_t> &interim_neighbors, std::vector<size_t> &type_counts, std::vector<Type> &type_values,
-    std::vector<size_t> &destination_offsets, uint64_t right_weight, std::span<NodeId> out_neighbors,
-    std::span<Type> out_edge_types, NodeId default_node_id, Type default_edge_type,
-    boost::random::uniform_real_distribution<double> &toss, snark::Xoroshiro128PlusGenerator &gen) const
-{
-    size_t left_max = std::min(count, left_weight);
-    size_t left_pos = 0;
-    size_t right_max = std::min(count, right_weight);
-    size_t right_pos = 0;
-
-    size_t out_pos = 0;
-    for (; out_pos < count && (left_weight + right_weight > 0); ++out_pos)
-    {
-        const auto merge_rate = float(left_weight) / (left_weight + right_weight);
-        if (left_pos < left_max && toss(gen) < merge_rate)
-        {
-            size_t pick = size_t(toss(gen) * (left_max - left_pos)) + left_pos;
-            std::swap(left_neighbors[pick], left_neighbors[left_pos]);
-            std::swap(left_types[pick], left_types[left_pos]);
-            out_neighbors[out_pos] = left_neighbors[left_pos];
-            out_edge_types[out_pos] = left_types[left_pos];
-            ++left_pos;
-            --left_weight;
-        }
-        else if (right_pos < right_max)
-        {
-            // It is important to do conversion to size_t first, because if a random generator
-            // produces 0.999994, then result might be equal right_max, because float doesn't have
-            // enough precision(e.g. 0.99994*(24-9)+9 = 24 in floats vs 23 in size_t).
-            size_t pick = size_t(toss(gen) * (right_max - right_pos)) + right_pos;
-            std::swap(interim_neighbors[pick], interim_neighbors[right_pos]);
-
-            // Recover destination id: first determine edge type and then use destination offset to find the
-            // node_id. For example if the total number of neighbors is 5 and number of edge types is 2 and 3. This
-            // means the type counts vector will store accumulated counts [2, 5]. So when we sample indices 1 and 4,
-            // then we'll use std::lower_bound to find the edge types are 0 and 1 respectively. First edge
-            // destination will use offset 1-0=1 in the m_edge_destination array for a given edge type and second
-            // edge offset will be 4-2=2 for type 1.
-            size_t type_offset =
-                std::lower_bound(std::begin(type_counts), std::end(type_counts), interim_neighbors[right_pos] + 1) -
-                std::begin(type_counts);
-            out_edge_types[out_pos] = type_values[type_offset];
-            size_t prev_type = type_offset == 0 ? 0 : type_counts[type_offset - 1];
-            out_neighbors[out_pos] =
-                m_edge_destination[destination_offsets[type_offset] + interim_neighbors[right_pos] - prev_type];
-            ++right_pos;
-            --right_weight;
         }
         else
         {
-            --out_pos;
+            const auto curr_weight =
+                m_edge_type_offset[neighbor_type_index + 1] - m_edge_type_offset[neighbor_type_index];
+            out_partition_count += curr_weight;
+            const size_t local_offset = m_edge_type_offset[neighbor_type_index];
+            auto dst_span = std::span(m_edge_destination).subspan(local_offset, curr_weight);
+            replacement_sampler.add(curr_weight,
+                                    [out_nodes, out_types, out_edge_created_ts, tp = m_edge_types[neighbor_type_index],
+                                     dst_span, this](size_t pick, size_t offset) {
+                                        out_nodes[pick] = dst_span[offset];
+                                        out_types[pick] = tp;
+                                        out_edge_created_ts[pick] = PLACEHOLDER_TIMESTAMP;
+                                    });
         }
-    }
-    for (; out_pos < count; ++out_pos)
-    {
-        out_neighbors[out_pos] = default_node_id;
-        out_edge_types[out_pos] = default_edge_type;
     }
 }
 
-void Partition::UniformSampleNeighborWithoutReplacement(int64_t seed, uint64_t internal_id,
-                                                        std::optional<Timestamp> node_ts,
+void Partition::UniformSampleNeighborWithoutReplacement(uint64_t internal_id, std::optional<Timestamp> node_ts,
                                                         std::span<const Type> in_edge_types, uint64_t count,
                                                         std::span<NodeId> out_nodes, std::span<Type> out_types,
+                                                        std::span<Timestamp> out_edge_created_ts,
                                                         uint64_t &out_partition_count, NodeId default_node_id,
-                                                        Type default_edge_type) const
+                                                        Type default_edge_type, AlgorithmL &sampler) const
 {
-    assert(!node_ts.has_value());
-    size_t pos = 0;
-    snark::Xoroshiro128PlusGenerator gen(seed);
-    boost::random::uniform_real_distribution<double> toss(0, 1);
-
-    // Temporary variables, allocate memory once and reuse it for every node.
-    std::vector<size_t> type_counts;
-    type_counts.reserve(in_edge_types.size());
-    std::vector<Type> type_values;
-    type_values.reserve(in_edge_types.size());
-    std::vector<size_t> destination_offsets;
-    destination_offsets.reserve(in_edge_types.size());
-    std::vector<size_t> interim_neighbors;
-    interim_neighbors.reserve(count);
-    std::vector<NodeId> prev_nodes;
-    prev_nodes.reserve(count);
-    std::vector<Type> prev_types;
-    prev_types.reserve(count);
-
     const auto offset = m_neighbors_index[internal_id];
     const auto nb_count = m_neighbors_index[internal_id + 1] - offset;
 
     size_t curr_type = 0;
     const auto last_type = offset + nb_count;
 
-    // In order to avoid storing all node neighbors we'll find the total number of neighbors for given types
-    // and then sample from a continuous range of elements from 1..#neighbors.
-    // We store `type_counts`, `type_values` and `destination_offsets` to recover destination node ids later
-    // by sampled indices with O(log(#edge_types)) complexity.
-    type_counts.clear();
-    type_values.clear();
-    destination_offsets.clear();
-    interim_neighbors.clear();
-    size_t partition_weight = 0;
     for (size_t i = offset; i < last_type; ++i)
     {
         if (!advance_edge_types(curr_type, i, in_edge_types, m_edge_types, last_type))
@@ -1562,26 +1459,56 @@ void Partition::UniformSampleNeighborWithoutReplacement(int64_t seed, uint64_t i
             continue;
         }
 
-        const auto curr_weight = m_edge_type_offset[i + 1] - m_edge_type_offset[i];
-        partition_weight += curr_weight;
-        type_counts.emplace_back(partition_weight);
-        type_values.emplace_back(m_edge_types[i]);
-        destination_offsets.emplace_back(m_edge_type_offset[i]);
+        if (node_ts.has_value() && !m_edge_timestamps.empty())
+        {
+            auto first = m_edge_type_offset[i];
+            auto last = m_edge_type_offset[i + 1] - 1;
+            ++last;
+            auto timestamp_span = std::span(m_edge_timestamps).subspan(first, last - first);
+            for (auto it = find_start(timestamp_span, node_ts.value());
+                 it != std::end(timestamp_span) && !(it->second == -1 && it->first > node_ts.value());
+                 it = find_start(timestamp_span, node_ts.value()))
+            {
+                const size_t it_dist = it - std::begin(timestamp_span);
+                const auto it_subspan = timestamp_span.subspan(it_dist);
+                auto lst = find_last(it_subspan, node_ts.value());
+                auto stream = it_subspan.subspan(0, lst - std::begin(it_subspan));
+
+                const auto stream_size = stream.size();
+                out_partition_count += stream_size;
+                auto dest_span = std::span(m_edge_destination).subspan(first + it_dist, stream_size);
+                auto ts_span = std::span(m_edge_timestamps).subspan(first + it_dist, stream_size);
+                sampler.add(stream_size, [&dest_span, &out_nodes, &out_types, &out_edge_created_ts, ts_span,
+                                          tp = in_edge_types[curr_type]](size_t pick, size_t offset) {
+                    out_nodes[pick] = dest_span[offset];
+                    out_types[pick] = tp;
+                    out_edge_created_ts[pick] = ts_span[offset].first;
+                });
+
+                if (lst ==
+                    std::begin(it_subspan)) // cheking if positions are the same (lst == it) for different iterators.
+                {
+                    ++lst;
+                }
+                const auto local_pos =
+                    size_t((lst - std::begin(it_subspan)) + it_dist); // equivavlent of lst - std::begin(timestamp_span)
+                timestamp_span = timestamp_span.subspan(local_pos);
+            }
+        }
+        else
+        {
+            auto first = m_edge_type_offset[i];
+            auto last = m_edge_type_offset[i + 1];
+            const auto stream_size = last - first;
+            out_partition_count += stream_size;
+            auto dest_span = std::span(m_edge_destination).subspan(first, stream_size);
+            sampler.add(dest_span.size(), [&dest_span, &out_nodes, &out_types,
+                                           tp = in_edge_types[curr_type]](size_t pick, size_t offset) {
+                out_nodes[pick] = dest_span[offset];
+                out_types[pick] = tp;
+            });
+        }
     }
-
-    contiguous_uniform_sample_helper(partition_weight, count, interim_neighbors, toss, gen);
-
-    size_t prev_max = std::min(count, out_partition_count);
-    prev_nodes.assign(std::begin(out_nodes) + pos, std::begin(out_nodes) + pos + prev_max);
-    prev_types.assign(std::begin(out_types) + pos, std::begin(out_types) + pos + prev_max);
-
-    UniformSampleMergeWithoutReplacement(count, prev_nodes, prev_types, out_partition_count, interim_neighbors,
-                                         type_counts, type_values, destination_offsets, partition_weight,
-                                         out_nodes.subspan(pos, count), out_types.subspan(pos, count), default_node_id,
-                                         default_edge_type, toss, gen);
-
-    pos += count;
-    out_partition_count += partition_weight;
 }
 
 Metadata Partition::GetMetadata() const

--- a/src/cc/lib/graph/partition.h
+++ b/src/cc/lib/graph/partition.h
@@ -14,6 +14,7 @@
 #include <vector>
 
 #include "metadata.h"
+#include "reservoir.h"
 #include "storage.h"
 #include "types.h"
 #include "xoroshiro.h"
@@ -67,7 +68,7 @@ struct Partition
     // with id equal to node_id and returns total number of such neighbors.
     size_t FullNeighbor(uint64_t internal_node_id, std::optional<Timestamp> timestamp, std::span<const Type> edge_types,
                         std::vector<NodeId> &out_neighbors_ids, std::vector<Type> &out_edge_types,
-                        std::vector<float> &out_edge_weights) const;
+                        std::vector<float> &out_edge_weights, std::vector<Timestamp> &out_edge_created_ts) const;
 
     // in_edge_types has to have types in strictly increasing order.
     // out_partition contains information about neighbor weights for a
@@ -75,14 +76,16 @@ struct Partition
     // are distributed accross multiple partitions.
     void SampleNeighbor(int64_t seed, uint64_t internal_node_id, std::optional<Timestamp> timestamp,
                         std::span<const Type> in_edge_types, uint64_t count, std::span<NodeId> out_nodes,
-                        std::span<Type> out_types, std::span<float> out_weights, float &out_partition,
-                        NodeId default_node_id, float default_weight, Type default_type) const;
+                        std::span<Type> out_types, std::span<float> out_weights,
+                        std::span<Timestamp> out_edge_created_ts, float &out_partition, NodeId default_node_id,
+                        float default_weight, Type default_type) const;
 
     // in_edge_types has to have types in strictly increasing order.
-    void UniformSampleNeighbor(bool without_replacement, int64_t seed, uint64_t internal_node_id,
-                               std::optional<Timestamp> timestamp, std::span<const Type> in_edge_types, uint64_t count,
-                               std::span<NodeId> out_nodes, std::span<Type> out_types, uint64_t &out_partition_count,
-                               NodeId default_node_id, Type default_edge_type) const;
+    void UniformSampleNeighbor(bool without_replacement, uint64_t internal_node_id, std::optional<Timestamp> timestamp,
+                               std::span<const Type> in_edge_types, uint64_t count, std::span<NodeId> out_nodes,
+                               std::span<Type> out_types, std::span<Timestamp> out_edge_created_ts,
+                               uint64_t &out_partition_count, NodeId default_node_id, Type default_edge_type,
+                               AlgorithmL &sampler, WithReplacement &replacement_sampler) const;
 
     // Same as above, in_edge_types has to have types in strictly increasing order.
     size_t LastNCreatedNeighbors(uint64_t internal_node_id, Timestamp timestamp, std::span<const Type> in_edge_types,
@@ -108,23 +111,18 @@ struct Partition
     void ReadEdgeFeaturesData(std::filesystem::path path, std::string suffix);
     void ReadEdgeTimestamps(std::filesystem::path path, std::string suffix);
 
-    void UniformSampleNeighborWithoutReplacement(int64_t seed, uint64_t internal_node_ids,
-                                                 std::optional<Timestamp> timestamp,
+    void UniformSampleNeighborWithoutReplacement(uint64_t internal_node_ids, std::optional<Timestamp> timestamp,
                                                  std::span<const Type> in_edge_types, uint64_t count,
                                                  std::span<NodeId> out_nodes, std::span<Type> out_types,
+                                                 std::span<Timestamp> out_edge_created_ts,
                                                  uint64_t &out_partition_count, NodeId default_node_id,
-                                                 Type default_edge_type) const;
-    void UniformSampleNeighborWithReplacement(int64_t seed, uint64_t internal_node_ids,
-                                              std::optional<Timestamp> timestamp, std::span<const Type> in_edge_types,
-                                              uint64_t count, std::span<NodeId> out_nodes, std::span<Type> out_types,
-                                              uint64_t &out_partition_count, NodeId default_node_id,
-                                              Type default_edge_type) const;
-    void UniformSampleMergeWithoutReplacement(
-        uint64_t count, std::vector<NodeId> &left_neighbors, std::vector<Type> &left_types, uint64_t left_weight,
-        std::vector<size_t> &interim_neighbors, std::vector<size_t> &type_counts, std::vector<Type> &type_values,
-        std::vector<size_t> &destination_offsets, uint64_t right_weight, std::span<NodeId> out_neighbors,
-        std::span<Type> out_edge_types, NodeId default_node_id, Type default_edge_type,
-        boost::random::uniform_real_distribution<double> &toss, snark::Xoroshiro128PlusGenerator &gen) const;
+                                                 Type default_edge_type, AlgorithmL &sampler) const;
+    void UniformSampleNeighborWithReplacement(uint64_t internal_node_ids, std::optional<Timestamp> timestamp,
+                                              std::span<const Type> in_edge_types, uint64_t count,
+                                              std::span<NodeId> out_nodes, std::span<Type> out_types,
+                                              std::span<Timestamp> out_edge_created_ts, uint64_t &out_partition_count,
+                                              NodeId default_node_id, Type default_edge_type,
+                                              WithReplacement &replacement_sampler) const;
 
     // Node features
     std::shared_ptr<BaseStorage<uint8_t>> m_node_features;

--- a/src/cc/lib/graph/partition.h
+++ b/src/cc/lib/graph/partition.h
@@ -7,6 +7,7 @@
 #include <cstdlib>
 #include <filesystem>
 #include <optional>
+#include <queue>
 #include <random>
 #include <span>
 #include <string>
@@ -24,6 +25,8 @@
 
 namespace snark
 {
+using ts_position = std::pair<Timestamp, size_t>;
+using lastn_queue = std::priority_queue<ts_position, std::vector<ts_position>, std::greater<ts_position>>;
 struct Partition
 {
     Partition() = default;
@@ -66,33 +69,35 @@ struct Partition
 
     // Backfill out_* vectors with information about neighbors of the node
     // with id equal to node_id and returns total number of such neighbors.
-    size_t FullNeighbor(uint64_t internal_node_id, std::optional<Timestamp> timestamp, std::span<const Type> edge_types,
-                        std::vector<NodeId> &out_neighbors_ids, std::vector<Type> &out_edge_types,
-                        std::vector<float> &out_edge_weights, std::vector<Timestamp> &out_edge_created_ts) const;
+    size_t FullNeighbor(bool return_edge_created_ts, uint64_t internal_node_id, std::optional<Timestamp> timestamp,
+                        std::span<const Type> edge_types, std::vector<NodeId> &out_neighbors_ids,
+                        std::vector<Type> &out_edge_types, std::vector<float> &out_edge_weights,
+                        std::vector<Timestamp> &out_edge_created_ts) const;
 
     // in_edge_types has to have types in strictly increasing order.
     // out_partition contains information about neighbor weights for a
     // particular node in that partition. This is useful in case node neighbors
     // are distributed accross multiple partitions.
-    void SampleNeighbor(int64_t seed, uint64_t internal_node_id, std::optional<Timestamp> timestamp,
-                        std::span<const Type> in_edge_types, uint64_t count, std::span<NodeId> out_nodes,
-                        std::span<Type> out_types, std::span<float> out_weights,
+    void SampleNeighbor(bool return_edge_created_ts, int64_t seed, uint64_t internal_node_id,
+                        std::optional<Timestamp> timestamp, std::span<const Type> in_edge_types, uint64_t count,
+                        std::span<NodeId> out_nodes, std::span<Type> out_types, std::span<float> out_weights,
                         std::span<Timestamp> out_edge_created_ts, float &out_partition, NodeId default_node_id,
                         float default_weight, Type default_type) const;
 
     // in_edge_types has to have types in strictly increasing order.
-    void UniformSampleNeighbor(bool without_replacement, uint64_t internal_node_id, std::optional<Timestamp> timestamp,
-                               std::span<const Type> in_edge_types, uint64_t count, std::span<NodeId> out_nodes,
-                               std::span<Type> out_types, std::span<Timestamp> out_edge_created_ts,
-                               uint64_t &out_partition_count, NodeId default_node_id, Type default_edge_type,
-                               AlgorithmL &sampler, WithReplacement &replacement_sampler) const;
+    void UniformSampleNeighbor(bool without_replacement, bool return_edge_created_ts, uint64_t internal_node_id,
+                               std::optional<Timestamp> timestamp, std::span<const Type> in_edge_types, uint64_t count,
+                               std::span<NodeId> out_nodes, std::span<Type> out_types,
+                               std::span<Timestamp> out_edge_created_ts, uint64_t &out_partition_count,
+                               NodeId default_node_id, Type default_edge_type, AlgorithmL &sampler,
+                               WithReplacement &replacement_sampler) const;
 
     // Same as above, in_edge_types has to have types in strictly increasing order.
-    size_t LastNCreatedNeighbors(uint64_t internal_node_id, Timestamp timestamp, std::span<const Type> in_edge_types,
-                                 uint64_t count, std::span<NodeId> out_nodes, std::span<Type> out_types,
-                                 std::span<float> out_edge_weights, std::span<Timestamp> out_timestamps,
-                                 NodeId default_node_id, Type default_edge_type, float default_weight,
-                                 Timestamp default_timestamp) const;
+    size_t LastNCreatedNeighbors(bool return_edge_created_ts, uint64_t internal_node_id, Timestamp timestamp,
+                                 std::span<const Type> in_edge_types, uint64_t count, std::span<NodeId> out_nodes,
+                                 std::span<Type> out_types, std::span<float> out_edge_weights,
+                                 std::span<Timestamp> out_timestamps, lastn_queue &lastn, NodeId default_node_id,
+                                 Type default_edge_type, float default_weight, Timestamp default_timestamp) const;
 
     Metadata GetMetadata() const;
 
@@ -111,15 +116,16 @@ struct Partition
     void ReadEdgeFeaturesData(std::filesystem::path path, std::string suffix);
     void ReadEdgeTimestamps(std::filesystem::path path, std::string suffix);
 
-    void UniformSampleNeighborWithoutReplacement(uint64_t internal_node_ids, std::optional<Timestamp> timestamp,
+    void UniformSampleNeighborWithoutReplacement(bool return_edge_created_ts, uint64_t internal_node_ids,
+                                                 std::optional<Timestamp> timestamp,
                                                  std::span<const Type> in_edge_types, uint64_t count,
                                                  std::span<NodeId> out_nodes, std::span<Type> out_types,
                                                  std::span<Timestamp> out_edge_created_ts,
                                                  uint64_t &out_partition_count, NodeId default_node_id,
                                                  Type default_edge_type, AlgorithmL &sampler) const;
-    void UniformSampleNeighborWithReplacement(uint64_t internal_node_ids, std::optional<Timestamp> timestamp,
-                                              std::span<const Type> in_edge_types, uint64_t count,
-                                              std::span<NodeId> out_nodes, std::span<Type> out_types,
+    void UniformSampleNeighborWithReplacement(bool return_edge_created_ts, uint64_t internal_node_ids,
+                                              std::optional<Timestamp> timestamp, std::span<const Type> in_edge_types,
+                                              uint64_t count, std::span<NodeId> out_nodes, std::span<Type> out_types,
                                               std::span<Timestamp> out_edge_created_ts, uint64_t &out_partition_count,
                                               NodeId default_node_id, Type default_edge_type,
                                               WithReplacement &replacement_sampler) const;

--- a/src/cc/lib/graph/reservoir.cc
+++ b/src/cc/lib/graph/reservoir.cc
@@ -1,0 +1,72 @@
+#include <cassert>
+#include <cmath>
+
+#include "reservoir.h"
+
+namespace snark
+{
+
+AlgorithmL::AlgorithmL(size_t k, snark::Xoroshiro128PlusGenerator &gen)
+    : m_k(k), m_W{0}, m_next(0), m_seen(0), m_gen(gen),
+      m_dist(boost::random::uniform_real_distribution<float>(0.0f, 1.0f))
+{
+    assert(k > 0);
+}
+
+void AlgorithmL::add(size_t n, std::function<void(size_t, size_t)> update)
+{
+    size_t i = 0;
+    for (; m_seen < m_k && i < n; ++m_seen, ++i, ++m_next)
+    {
+        update(m_seen, i);
+    }
+
+    size_t left = n - i;
+    // Check if we can postpone random number generation.
+    if (left == 0)
+    {
+        return;
+    }
+
+    if (m_seen == m_k)
+    {
+        m_W = std::exp(std::log(m_dist(m_gen)) / m_k);
+        m_next += std::floor(std::log(m_dist(m_gen)) / std::log(1 - m_W)) + 1;
+    }
+
+    while (m_next <= m_seen + left) // First time we've seen more than m_k elements
+    {
+        const size_t range_offset = m_seen + left - m_next + i;
+        const size_t new_left = n - range_offset;
+        m_seen += left - new_left;
+        left = new_left;
+        size_t pick = m_dist(m_gen) * m_k;
+        update(pick, range_offset);
+
+        m_W *= std::exp(std::log(m_dist(m_gen)) / m_k);
+        m_next += std::floor(std::log(m_dist(m_gen)) / std::log(1 - m_W)) + 1;
+    }
+
+    m_seen += left;
+}
+
+WithReplacement::WithReplacement(size_t k, snark::Xoroshiro128PlusGenerator &gen)
+    : m_seen(0), m_k(k), m_gen(gen), m_dist(boost::random::uniform_real_distribution<float>(0.0f, 1.0f))
+{
+    assert(k > 0);
+}
+
+void WithReplacement::add(size_t n, std::function<void(size_t, size_t)> update)
+{
+    m_seen += n;
+    const float rate = float(n) / m_seen;
+    for (size_t i = 0; i < m_k; ++i)
+    {
+        if (rate == 1.0f || m_dist(m_gen) < rate)
+        {
+            update(i, size_t(n * m_dist(m_gen)));
+        }
+    }
+}
+
+} // namespace snark

--- a/src/cc/lib/graph/reservoir.h
+++ b/src/cc/lib/graph/reservoir.h
@@ -1,0 +1,59 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#ifndef SNARK_RESERVOIR_H
+#define SNARK_RESERVOIR_H
+
+#include <functional>
+#include <span>
+
+#include "boost/random/uniform_real_distribution.hpp"
+
+#include "xoroshiro.h"
+
+namespace snark
+{
+
+// Implementation of an optimal algorithm for reservoir sampling:
+// https://en.wikipedia.org/wiki/Reservoir_sampling#Optimal:_Algorithm_L
+class AlgorithmL
+{
+  public:
+    // `k` is the size of reservoir, short name to be consistent with reference.
+    // gen is the random generator to use for sampling and support for setting seeds in clients.
+    AlgorithmL(size_t k, snark::Xoroshiro128PlusGenerator &gen);
+
+    // add n elements to the reservoir. Every time an element is selected to put in a reservoir,
+    // the update function is called. We use a callback approach, because we usually need to fetch
+    // elements from multiple sources (edge type, destination, timestamps). Arguments passed to the callback
+    // are (pick, offset). Pick is the index of element in the reservoir to be replaced in the range [0; k).
+    // Offset is the offset in the stream in the range [0, n).
+    // Method might be called multiple times which will result in merging multiple streams into one.
+    void add(size_t n, std::function<void(size_t, size_t)> update);
+
+  private:
+    size_t m_k;
+    float m_W;
+    size_t m_next;
+    size_t m_seen;
+    snark::Xoroshiro128PlusGenerator &m_gen;
+    boost::random::uniform_real_distribution<float> m_dist;
+};
+
+// Following paper "Reservoir-based Random Sampling with Replacement from Data Stream" by BH Park · 2004
+class WithReplacement
+{
+  public:
+    WithReplacement(size_t k, snark::Xoroshiro128PlusGenerator &gen);
+
+    void add(size_t n, std::function<void(size_t, size_t)> update);
+
+  private:
+    size_t m_seen;
+    size_t m_k;
+    snark::Xoroshiro128PlusGenerator &m_gen;
+    boost::random::uniform_real_distribution<float> m_dist;
+};
+} // namespace snark
+
+#endif

--- a/src/cc/lib/graph/types.h
+++ b/src/cc/lib/graph/types.h
@@ -17,6 +17,7 @@ using Timestamp = int64_t;
 using FeatureMeta = std::pair<FeatureId, FeatureSize>;
 
 const int32_t PLACEHOLDER_NODE_TYPE = -1;
+const Timestamp PLACEHOLDER_TIMESTAMP = -1;
 
 // Enum ordering should match PyPartitionStorageType in py_graph.h.
 enum PartitionStorageType

--- a/src/cc/lib/py_graph.cc
+++ b/src/cc/lib/py_graph.cc
@@ -625,8 +625,9 @@ int32_t GetEdgeStringFeature(PyGraph *py_graph, NodeID *edge_src_ids, NodeID *ed
     return 0;
 }
 
-int32_t GetNeighborsInternal(PyGraph *py_graph, NodeID *in_node_ids, size_t in_node_ids_size, Timestamp *timestamps,
-                             Type *in_edge_types, size_t in_edge_types_size, uint64_t *out_neighbor_counts,
+int32_t GetNeighborsInternal(PyGraph *py_graph, bool return_edge_created_ts, NodeID *in_node_ids,
+                             size_t in_node_ids_size, Timestamp *timestamps, Type *in_edge_types,
+                             size_t in_edge_types_size, uint64_t *out_neighbor_counts,
                              std::vector<NodeID> &out_neighbor_ids, std::vector<Type> &out_edge_types,
                              std::vector<float> &out_edge_weights, std::vector<Timestamp> &out_edge_created_ts)
 {
@@ -640,7 +641,7 @@ int32_t GetNeighborsInternal(PyGraph *py_graph, NodeID *in_node_ids, size_t in_n
     if (py_graph->graph->graph)
     {
         py_graph->graph->graph->FullNeighbor(
-            std::span(reinterpret_cast<snark::NodeId *>(in_node_ids), in_node_ids_size),
+            return_edge_created_ts, std::span(reinterpret_cast<snark::NodeId *>(in_node_ids), in_node_ids_size),
             std::span(reinterpret_cast<snark::Type *>(in_edge_types), in_edge_types_size),
             std::span(reinterpret_cast<snark::Timestamp *>(timestamps), timestamps == nullptr ? 0 : in_node_ids_size),
             out_neighbor_ids, out_edge_types, out_edge_weights, out_edge_created_ts,
@@ -651,7 +652,7 @@ int32_t GetNeighborsInternal(PyGraph *py_graph, NodeID *in_node_ids, size_t in_n
     try
     {
         py_graph->graph->client->FullNeighbor(
-            std::span(reinterpret_cast<snark::NodeId *>(in_node_ids), in_node_ids_size),
+            return_edge_created_ts, std::span(reinterpret_cast<snark::NodeId *>(in_node_ids), in_node_ids_size),
             std::span(reinterpret_cast<snark::Type *>(in_edge_types), in_edge_types_size),
             std::span(reinterpret_cast<snark::Timestamp *>(timestamps), timestamps == nullptr ? 0 : in_node_ids_size),
             out_neighbor_ids, out_edge_types, out_edge_weights, out_edge_created_ts,
@@ -705,18 +706,18 @@ int32_t NeighborCount(PyGraph *py_graph, NodeID *in_node_ids, size_t in_node_ids
     return 0;
 }
 
-int32_t GetNeighbors(PyGraph *py_graph, NodeID *in_node_ids, size_t in_node_ids_size, Timestamp *timestamps,
-                     Type *in_edge_types, size_t in_edge_types_size, uint64_t *out_neighbor_counts,
-                     GetNeighborsCallback callback)
+int32_t GetNeighbors(PyGraph *py_graph, bool return_edge_created_ts, NodeID *in_node_ids, size_t in_node_ids_size,
+                     Timestamp *timestamps, Type *in_edge_types, size_t in_edge_types_size,
+                     uint64_t *out_neighbor_counts, GetNeighborsCallback callback)
 {
     std::vector<snark::NodeId> neighbor_ids;
     std::vector<snark::Type> edge_types;
     std::vector<float> edge_weights;
     std::vector<snark::Timestamp> edge_created_ts;
     std::fill_n(out_neighbor_counts, in_node_ids_size, 0);
-    const auto res =
-        GetNeighborsInternal(py_graph, in_node_ids, in_node_ids_size, timestamps, in_edge_types, in_edge_types_size,
-                             out_neighbor_counts, neighbor_ids, edge_types, edge_weights, edge_created_ts);
+    const auto res = GetNeighborsInternal(py_graph, return_edge_created_ts, in_node_ids, in_node_ids_size, timestamps,
+                                          in_edge_types, in_edge_types_size, out_neighbor_counts, neighbor_ids,
+                                          edge_types, edge_weights, edge_created_ts);
     if (res != 0)
     {
         return res;
@@ -726,11 +727,11 @@ int32_t GetNeighbors(PyGraph *py_graph, NodeID *in_node_ids, size_t in_node_ids_
     return 0;
 }
 
-int32_t WeightedSampleNeighbor(PyGraph *py_graph, int64_t seed, NodeID *in_node_ids, size_t in_node_ids_size,
-                               Type *in_edge_types, size_t in_edge_types_size, Timestamp *timestamps, size_t count,
-                               NodeID *out_neighbor_ids, Type *out_types, float *out_weights,
-                               Timestamp *out_edge_created_ts, NodeID default_node_id, float default_weight,
-                               Type default_edge_type)
+int32_t WeightedSampleNeighbor(PyGraph *py_graph, bool return_edge_created_ts, int64_t seed, NodeID *in_node_ids,
+                               size_t in_node_ids_size, Type *in_edge_types, size_t in_edge_types_size,
+                               Timestamp *timestamps, size_t count, NodeID *out_neighbor_ids, Type *out_types,
+                               float *out_weights, Timestamp *out_edge_created_ts, NodeID default_node_id,
+                               float default_weight, Type default_edge_type)
 {
     if (py_graph->graph == nullptr)
     {
@@ -743,7 +744,7 @@ int32_t WeightedSampleNeighbor(PyGraph *py_graph, int64_t seed, NodeID *in_node_
     if (py_graph->graph->graph)
     {
         py_graph->graph->graph->SampleNeighbor(
-            seed, std::span(reinterpret_cast<snark::NodeId *>(in_node_ids), in_node_ids_size),
+            return_edge_created_ts, seed, std::span(reinterpret_cast<snark::NodeId *>(in_node_ids), in_node_ids_size),
             std::span(reinterpret_cast<snark::Type *>(in_edge_types), in_edge_types_size),
             std::span(reinterpret_cast<snark::Timestamp *>(timestamps), timestamps == nullptr ? 0 : in_node_ids_size),
             count, std::span(reinterpret_cast<snark::NodeId *>(out_neighbor_ids), out_size),
@@ -758,7 +759,7 @@ int32_t WeightedSampleNeighbor(PyGraph *py_graph, int64_t seed, NodeID *in_node_
     try
     {
         py_graph->graph->client->WeightedSampleNeighbor(
-            seed, std::span(reinterpret_cast<snark::NodeId *>(in_node_ids), in_node_ids_size),
+            return_edge_created_ts, seed, std::span(reinterpret_cast<snark::NodeId *>(in_node_ids), in_node_ids_size),
             std::span(reinterpret_cast<snark::Type *>(in_edge_types), in_edge_types_size),
             std::span(reinterpret_cast<snark::Timestamp *>(timestamps), timestamps == nullptr ? 0 : in_node_ids_size),
             count, std::span(reinterpret_cast<snark::NodeId *>(out_neighbor_ids), out_size),
@@ -776,10 +777,11 @@ int32_t WeightedSampleNeighbor(PyGraph *py_graph, int64_t seed, NodeID *in_node_
     }
 }
 
-int32_t UniformSampleNeighbor(PyGraph *py_graph, bool without_replacement, int64_t seed, NodeID *in_node_ids,
-                              size_t in_node_ids_size, Type *in_edge_types, size_t in_edge_types_size,
-                              Timestamp *timestamps, size_t count, NodeID *out_neighbor_ids, Type *out_types,
-                              Timestamp *out_edge_created_ts, NodeID default_node_id, Type default_edge_type)
+int32_t UniformSampleNeighbor(PyGraph *py_graph, bool without_replacement, bool return_edge_created_ts, int64_t seed,
+                              NodeID *in_node_ids, size_t in_node_ids_size, Type *in_edge_types,
+                              size_t in_edge_types_size, Timestamp *timestamps, size_t count, NodeID *out_neighbor_ids,
+                              Type *out_types, Timestamp *out_edge_created_ts, NodeID default_node_id,
+                              Type default_edge_type)
 {
     if (py_graph->graph == nullptr)
     {
@@ -792,7 +794,8 @@ int32_t UniformSampleNeighbor(PyGraph *py_graph, bool without_replacement, int64
     {
         std::vector<uint64_t> total_neighbor_counts(in_node_ids_size);
         py_graph->graph->graph->UniformSampleNeighbor(
-            without_replacement, seed, std::span(reinterpret_cast<snark::NodeId *>(in_node_ids), in_node_ids_size),
+            without_replacement, return_edge_created_ts, seed,
+            std::span(reinterpret_cast<snark::NodeId *>(in_node_ids), in_node_ids_size),
             std::span(reinterpret_cast<snark::Type *>(in_edge_types), in_edge_types_size),
             std::span(reinterpret_cast<snark::Timestamp *>(timestamps), timestamps == nullptr ? 0 : in_node_ids_size),
             count, std::span(reinterpret_cast<snark::NodeId *>(out_neighbor_ids), out_size),
@@ -808,7 +811,8 @@ int32_t UniformSampleNeighbor(PyGraph *py_graph, bool without_replacement, int64
     try
     {
         py_graph->graph->client->UniformSampleNeighbor(
-            without_replacement, seed, std::span(reinterpret_cast<snark::NodeId *>(in_node_ids), in_node_ids_size),
+            without_replacement, return_edge_created_ts, seed,
+            std::span(reinterpret_cast<snark::NodeId *>(in_node_ids), in_node_ids_size),
             std::span(reinterpret_cast<snark::Type *>(in_edge_types), in_edge_types_size),
             std::span(reinterpret_cast<snark::Timestamp *>(timestamps), timestamps == nullptr ? 0 : in_node_ids_size),
             count, std::span(reinterpret_cast<snark::NodeId *>(out_neighbor_ids), out_size),
@@ -825,9 +829,10 @@ int32_t UniformSampleNeighbor(PyGraph *py_graph, bool without_replacement, int64
     }
 }
 
-int32_t LastNCreatedNeighbor(PyGraph *py_graph, NodeID *in_node_ids, size_t in_node_ids_size, Type *in_edge_types,
-                             size_t in_edge_types_size, Timestamp *timestamps, size_t count, NodeID *out_neighbor_ids,
-                             Type *out_types, float *out_weights, Timestamp *out_timestamps, NodeID default_node_id,
+int32_t LastNCreatedNeighbor(PyGraph *py_graph, bool return_edge_created_ts, NodeID *in_node_ids,
+                             size_t in_node_ids_size, Type *in_edge_types, size_t in_edge_types_size,
+                             Timestamp *timestamps, size_t count, NodeID *out_neighbor_ids, Type *out_types,
+                             float *out_weights, Timestamp *out_timestamps, NodeID default_node_id,
                              float default_weight, Type default_edge_type, Timestamp default_timestamp)
 {
     if (py_graph->graph == nullptr)
@@ -840,7 +845,7 @@ int32_t LastNCreatedNeighbor(PyGraph *py_graph, NodeID *in_node_ids, size_t in_n
     if (py_graph->graph->graph)
     {
         py_graph->graph->graph->LastNCreated(
-            std::span(reinterpret_cast<snark::NodeId *>(in_node_ids), in_node_ids_size),
+            return_edge_created_ts, std::span(reinterpret_cast<snark::NodeId *>(in_node_ids), in_node_ids_size),
             std::span(reinterpret_cast<snark::Type *>(in_edge_types), in_edge_types_size),
             std::span(reinterpret_cast<snark::Timestamp *>(timestamps), in_node_ids_size), count,
             std::span(reinterpret_cast<snark::NodeId *>(out_neighbor_ids), out_size),
@@ -852,25 +857,25 @@ int32_t LastNCreatedNeighbor(PyGraph *py_graph, NodeID *in_node_ids, size_t in_n
         return 0;
     }
 
-    try
-    {
-        py_graph->graph->client->LastNCreated(
-            std::span(reinterpret_cast<snark::NodeId *>(in_node_ids), in_node_ids_size),
-            std::span(reinterpret_cast<snark::Type *>(in_edge_types), in_edge_types_size),
-            std::span(reinterpret_cast<snark::Timestamp *>(timestamps), in_node_ids_size), count,
-            std::span(reinterpret_cast<snark::NodeId *>(out_neighbor_ids), out_size),
-            std::span(reinterpret_cast<snark::Type *>(out_types), out_size),
-            std::span(reinterpret_cast<float *>(out_weights), out_size),
-            std::span(reinterpret_cast<Timestamp *>(out_timestamps), out_size), default_node_id, default_weight,
-            default_edge_type, default_timestamp);
+    // try
+    // {
+    py_graph->graph->client->LastNCreated(
+        return_edge_created_ts, std::span(reinterpret_cast<snark::NodeId *>(in_node_ids), in_node_ids_size),
+        std::span(reinterpret_cast<snark::Type *>(in_edge_types), in_edge_types_size),
+        std::span(reinterpret_cast<snark::Timestamp *>(timestamps), in_node_ids_size), count,
+        std::span(reinterpret_cast<snark::NodeId *>(out_neighbor_ids), out_size),
+        std::span(reinterpret_cast<snark::Type *>(out_types), out_size),
+        std::span(reinterpret_cast<float *>(out_weights), out_size),
+        std::span(reinterpret_cast<Timestamp *>(out_timestamps), out_size), default_node_id, default_weight,
+        default_edge_type, default_timestamp);
 
-        return 0;
-    }
-    catch (const std::exception &e)
-    {
-        RAW_LOG_ERROR("Exception while selecting last n created neighbors: %s", e.what());
-        return 1;
-    }
+    return 0;
+    // }
+    // catch (const std::exception &e)
+    // {
+    //     RAW_LOG_ERROR("Exception while selecting last n created neighbors: %s", e.what());
+    //     return 1;
+    // }
 }
 
 // Expected length of out_node_ids buffer is (walk_length + 1) * in_node_ids_size
@@ -930,7 +935,7 @@ int32_t RandomWalk(PyGraph *py_graph, int64_t seed, float p, float q, NodeID def
         weights.resize(0);
         types.resize(0);
         edge_created_ts.resize(0);
-        GetNeighborsInternal(py_graph, curr_nodes.data(), curr_nodes.size(), timestamps, in_edge_types,
+        GetNeighborsInternal(py_graph, false, curr_nodes.data(), curr_nodes.size(), timestamps, in_edge_types,
                              in_edge_types_size, curr_counts.data(), neighbors, types, weights, edge_created_ts);
         size_t nb_offset = 0;
         for (size_t index = 0; index < in_node_ids_size; ++index)
@@ -1117,9 +1122,11 @@ void lookup_neighbor_lists(PyGraph *py_graph, NB_Count_Cache &cache,
     if (!cache.node_ids.empty())
     {
         cache.nb_counts.resize(cache.node_ids.size());
-        GetNeighborsInternal(py_graph, cache.node_ids.data(), cache.node_ids.size(), mutable_timestamps, in_edge_types,
-                             in_edge_types_size, cache.nb_counts.data(), cache.nb_ids, cache.nb_types, cache.nb_weights,
-                             cache.edge_created_ts);
+        GetNeighborsInternal(py_graph, false, cache.node_ids.data(), cache.node_ids.size(), mutable_timestamps,
+                             in_edge_types, in_edge_types_size, cache.nb_counts.data(), cache.nb_ids, cache.nb_types,
+                             cache.nb_weights, cache.edge_created_ts);
+        assert(cache.edge_created_ts.empty());
+
         auto nb_offset = std::begin(cache.nb_ids);
         for (size_t i = 0; i < cache.node_ids.size(); ++i)
         {
@@ -1137,7 +1144,6 @@ void lookup_neighbor_lists(PyGraph *py_graph, NB_Count_Cache &cache,
 
     cache.node_ids.clear();
     cache.nb_ids.clear();
-    cache.edge_created_ts.clear();
     cache.nb_ids.reserve(input.size());
     for (const auto &nt : input)
     {
@@ -1149,7 +1155,6 @@ void lookup_neighbor_lists(PyGraph *py_graph, NB_Count_Cache &cache,
     cache.nb_types.clear();
     cache.nb_weights.clear();
     cache.nb_ids.clear();
-    cache.edge_created_ts.clear();
 }
 
 } // namespace
@@ -1158,7 +1163,7 @@ void lookup_neighbor_lists(PyGraph *py_graph, NB_Count_Cache &cache,
 int32_t PPRSampleNeighbor(PyGraph *py_graph, NodeID *in_node_ids, size_t in_node_ids_size, Timestamp *timestamps,
                           Type *in_edge_types, size_t in_edge_types_size, const size_t count, const float alpha,
                           const float eps, const NodeID default_node_id, const float default_weight,
-                          NodeID *out_neighbor_ids, float *out_weights, Timestamp *out_edge_created_ts)
+                          NodeID *out_neighbor_ids, float *out_weights)
 {
     if (py_graph->graph == nullptr)
     {

--- a/src/cc/lib/py_graph.h
+++ b/src/cc/lib/py_graph.h
@@ -73,7 +73,7 @@ extern "C"
     typedef int32_t Type;
     typedef int32_t Feature;
 
-    typedef void (*GetNeighborsCallback)(const NodeID *, const float *, const Type *, size_t);
+    typedef void (*GetNeighborsCallback)(const NodeID *, const float *, const Type *, const Timestamp *, size_t);
     typedef void (*GetSparseFeaturesCallback)(const int64_t **, size_t *, const uint8_t **, size_t *, int64_t *);
     typedef void (*GetStringFeaturesCallback)(size_t, const uint8_t *);
 
@@ -125,12 +125,13 @@ extern "C"
                                                       size_t in_node_ids_size, Type *in_edge_types,
                                                       size_t in_edge_types_size, Timestamp *time_stamps, size_t count,
                                                       NodeID *out_neighbor_ids, Type *out_types, float *out_weights,
-                                                      NodeID default_node_id, float default_weight,
-                                                      Type default_edge_type);
+                                                      Timestamp *out_created_ts, NodeID default_node_id,
+                                                      float default_weight, Type default_edge_type);
     DEEPGNN_DLL extern int32_t UniformSampleNeighbor(PyGraph *graph, bool without_replacement, int64_t seed,
                                                      NodeID *in_node_ids, size_t int_node_ids_size, Type *in_edge_types,
                                                      size_t in_edge_types_size, Timestamp *time_stamps, size_t count,
-                                                     NodeID *out_neighbor_ids, Type *out_types, NodeID default_node_id,
+                                                     NodeID *out_neighbor_ids, Type *out_types,
+                                                     Timestamp *out_created_ts, NodeID default_node_id,
                                                      Type default_edge_type);
 
     DEEPGNN_DLL extern int32_t RandomWalk(PyGraph *graph, int64_t seed, float p, float q, NodeID default_node_id,
@@ -141,7 +142,8 @@ extern "C"
     DEEPGNN_DLL extern int32_t PPRSampleNeighbor(PyGraph *graph, NodeID *in_node_ids, size_t in_node_ids_size,
                                                  Timestamp *timestamps, Type *in_edge_types, size_t in_edge_types_size,
                                                  size_t count, float alpha, float eps, NodeID default_node_id,
-                                                 float default_weight, NodeID *out_neighbor_ids, float *out_weights);
+                                                 float default_weight, NodeID *out_neighbor_ids, float *out_weights,
+                                                 Timestamp *out_created_ts);
 
     DEEPGNN_DLL extern int32_t LastNCreatedNeighbor(PyGraph *py_graph, NodeID *in_node_ids, size_t in_node_ids_size,
                                                     Type *in_edge_types, size_t in_edge_types_size,

--- a/src/cc/lib/py_graph.h
+++ b/src/cc/lib/py_graph.h
@@ -118,18 +118,20 @@ extern "C"
     DEEPGNN_DLL extern int32_t NeighborCount(PyGraph *py_graph, NodeID *in_node_ids, size_t in_node_ids_size,
                                              Timestamp *time_stamps, Type *in_edge_types, size_t in_edge_types_size,
                                              uint64_t *out_neighbor_counts);
-    DEEPGNN_DLL extern int32_t GetNeighbors(PyGraph *graph, NodeID *in_node_ids, size_t in_node_ids_size,
-                                            Timestamp *time_stamps, Type *in_edge_types, size_t in_edge_types_size,
-                                            uint64_t *out_neighbor_counts, GetNeighborsCallback callback);
-    DEEPGNN_DLL extern int32_t WeightedSampleNeighbor(PyGraph *graph, int64_t seed, NodeID *in_node_ids,
-                                                      size_t in_node_ids_size, Type *in_edge_types,
+    DEEPGNN_DLL extern int32_t GetNeighbors(PyGraph *graph, bool return_edge_created_ts, NodeID *in_node_ids,
+                                            size_t in_node_ids_size, Timestamp *time_stamps, Type *in_edge_types,
+                                            size_t in_edge_types_size, uint64_t *out_neighbor_counts,
+                                            GetNeighborsCallback callback);
+    DEEPGNN_DLL extern int32_t WeightedSampleNeighbor(PyGraph *graph, bool return_edge_created_ts, int64_t seed,
+                                                      NodeID *in_node_ids, size_t in_node_ids_size, Type *in_edge_types,
                                                       size_t in_edge_types_size, Timestamp *time_stamps, size_t count,
                                                       NodeID *out_neighbor_ids, Type *out_types, float *out_weights,
                                                       Timestamp *out_created_ts, NodeID default_node_id,
                                                       float default_weight, Type default_edge_type);
-    DEEPGNN_DLL extern int32_t UniformSampleNeighbor(PyGraph *graph, bool without_replacement, int64_t seed,
-                                                     NodeID *in_node_ids, size_t int_node_ids_size, Type *in_edge_types,
-                                                     size_t in_edge_types_size, Timestamp *time_stamps, size_t count,
+    DEEPGNN_DLL extern int32_t UniformSampleNeighbor(PyGraph *graph, bool without_replacement,
+                                                     bool return_edge_created_ts, int64_t seed, NodeID *in_node_ids,
+                                                     size_t int_node_ids_size, Type *in_edge_types,
+                                                     size_t in_edge_types_size, Timestamp *timestamps, size_t count,
                                                      NodeID *out_neighbor_ids, Type *out_types,
                                                      Timestamp *out_created_ts, NodeID default_node_id,
                                                      Type default_edge_type);
@@ -142,15 +144,15 @@ extern "C"
     DEEPGNN_DLL extern int32_t PPRSampleNeighbor(PyGraph *graph, NodeID *in_node_ids, size_t in_node_ids_size,
                                                  Timestamp *timestamps, Type *in_edge_types, size_t in_edge_types_size,
                                                  size_t count, float alpha, float eps, NodeID default_node_id,
-                                                 float default_weight, NodeID *out_neighbor_ids, float *out_weights,
-                                                 Timestamp *out_created_ts);
+                                                 float default_weight, NodeID *out_neighbor_ids, float *out_weights);
 
-    DEEPGNN_DLL extern int32_t LastNCreatedNeighbor(PyGraph *py_graph, NodeID *in_node_ids, size_t in_node_ids_size,
-                                                    Type *in_edge_types, size_t in_edge_types_size,
-                                                    Timestamp *timestamps, size_t count, NodeID *out_neighbor_ids,
-                                                    Type *out_types, float *out_weights, Timestamp *out_timestamps,
-                                                    NodeID default_node_id, float default_weight,
-                                                    Type default_edge_type, Timestamp default_timestamp);
+    DEEPGNN_DLL extern int32_t LastNCreatedNeighbor(PyGraph *py_graph, bool return_edge_created_ts, NodeID *in_node_ids,
+                                                    size_t in_node_ids_size, Type *in_edge_types,
+                                                    size_t in_edge_types_size, Timestamp *timestamps, size_t count,
+                                                    NodeID *out_neighbor_ids, Type *out_types, float *out_weights,
+                                                    Timestamp *out_timestamps, NodeID default_node_id,
+                                                    float default_weight, Type default_edge_type,
+                                                    Timestamp default_timestamp);
 
     // TODO(alsamylk): sorted neighbors
 

--- a/src/cc/tests/distributed_test.cc
+++ b/src/cc/tests/distributed_test.cc
@@ -528,12 +528,14 @@ TEST(DistributedTest, SampleNeighborsSingleServer)
     std::vector<snark::NodeId> output_nodes(nb_count * input_nodes.size());
     std::vector<float> output_weights(nb_count * input_nodes.size());
     std::vector<snark::Type> output_types(nb_count * input_nodes.size(), -1);
+    std::vector<snark::Timestamp> output_edge_ts(nb_count * input_nodes.size(), -6);
     client.WeightedSampleNeighbor(21, std::span(input_nodes), std::span(input_types), {}, nb_count,
-                                  std::span(output_nodes), std::span(output_types), std::span(output_weights), -1, 0.0f,
-                                  -1);
+                                  std::span(output_nodes), std::span(output_types), std::span(output_weights),
+                                  std::span(output_edge_ts), -1, 0.0f, -1);
     EXPECT_EQ(output_types, std::vector<snark::Type>(6, 0));
     EXPECT_EQ(output_nodes, std::vector<snark::NodeId>({3, 3, 3, 4, 5, 5}));
     EXPECT_EQ(output_weights, std::vector<float>({2, 2, 2, 2, 2, 2}));
+    EXPECT_EQ(output_edge_ts, std::vector<snark::Timestamp>(6, snark::PLACEHOLDER_TIMESTAMP));
 }
 
 TEST(DistributedTest, UniformSampleNeighborsSingleServer)
@@ -545,10 +547,12 @@ TEST(DistributedTest, UniformSampleNeighborsSingleServer)
     const size_t nb_count = 2;
     std::vector<snark::NodeId> output_nodes(nb_count * input_nodes.size());
     std::vector<snark::Type> output_types(nb_count * input_nodes.size(), -1);
+    std::vector<snark::Timestamp> output_edge_ts(nb_count * input_nodes.size(), -5);
     client.UniformSampleNeighbor(false, 21, std::span(input_nodes), std::span(input_types), {}, nb_count,
-                                 std::span(output_nodes), std::span(output_types), -1, -1);
+                                 std::span(output_nodes), std::span(output_types), std::span(output_edge_ts), -1, -1);
     EXPECT_EQ(output_types, std::vector<snark::Type>({0, 0, 0, 0, 0, 0}));
-    EXPECT_EQ(output_nodes, std::vector<snark::NodeId>({3, 3, 3, 5, 5, 6}));
+    EXPECT_EQ(output_nodes, std::vector<snark::NodeId>({3, 3, 5, 2, 4, 4}));
+    EXPECT_EQ(output_edge_ts, std::vector<snark::Timestamp>(6, snark::PLACEHOLDER_TIMESTAMP));
 }
 
 TEST(DistributedTest, UniformSampleNeighborsWithoutReplacementSingleServer)
@@ -560,10 +564,12 @@ TEST(DistributedTest, UniformSampleNeighborsWithoutReplacementSingleServer)
     const size_t nb_count = 2;
     std::vector<snark::NodeId> output_nodes(nb_count * input_nodes.size());
     std::vector<snark::Type> output_types(nb_count * input_nodes.size(), -1);
+    std::vector<snark::Timestamp> output_edge_ts(nb_count * input_nodes.size(), -2);
     client.UniformSampleNeighbor(true, 21, std::span(input_nodes), std::span(input_types), {}, nb_count,
-                                 std::span(output_nodes), std::span(output_types), -1, -1);
+                                 std::span(output_nodes), std::span(output_types), std::span(output_edge_ts), -1, -1);
     EXPECT_EQ(output_types, std::vector<snark::Type>({0, 0, 0, 0, 0, 0}));
-    EXPECT_EQ(output_nodes, std::vector<snark::NodeId>({1, 3, 2, 4, 6, 3}));
+    EXPECT_EQ(output_nodes, std::vector<snark::NodeId>({1, 4, 5, 4, 3, 5}));
+    EXPECT_EQ(output_edge_ts, std::vector<snark::Timestamp>(6, snark::PLACEHOLDER_TIMESTAMP));
 }
 
 using ServerList = std::vector<std::shared_ptr<snark::GRPCServer>>;
@@ -613,11 +619,14 @@ TEST(DistributedTest, SampleNeighborsMultipleServers)
     std::vector<snark::NodeId> output_nodes(nb_count * input_nodes.size());
     std::vector<float> output_weights(nb_count * input_nodes.size());
     std::vector<snark::Type> output_types(nb_count * input_nodes.size(), -1);
+    std::vector<snark::Timestamp> output_edge_ts(nb_count * input_nodes.size(), -4);
     c.WeightedSampleNeighbor(23, std::span(input_nodes), std::span(input_types), {}, nb_count, std::span(output_nodes),
-                             std::span(output_types), std::span(output_weights), -1, 0.0f, -1);
+                             std::span(output_types), std::span(output_weights), std::span(output_edge_ts), -1, 0.0f,
+                             -1);
     EXPECT_EQ(output_types, std::vector<snark::Type>(6, 0));
     EXPECT_EQ(output_nodes, std::vector<snark::NodeId>({2, 2, 57, 56, 80, 81}));
     EXPECT_EQ(output_weights, std::vector<float>({2, 2, 2, 1, 1, 2}));
+    EXPECT_EQ(output_edge_ts, std::vector<snark::Timestamp>(6, snark::PLACEHOLDER_TIMESTAMP));
 }
 
 TEST(DistributedTest, SampleNeighborsMultipleServersMissingNeighbors)
@@ -631,11 +640,14 @@ TEST(DistributedTest, SampleNeighborsMultipleServersMissingNeighbors)
     std::vector<snark::NodeId> output_nodes(nb_count * input_nodes.size());
     std::vector<float> output_weights(nb_count * input_nodes.size());
     std::vector<snark::Type> output_types(nb_count * input_nodes.size(), -1);
+    std::vector<snark::Timestamp> output_edge_ts(nb_count * input_nodes.size(), -2);
     c.WeightedSampleNeighbor(23, std::span(input_nodes), std::span(input_types), {}, nb_count, std::span(output_nodes),
-                             std::span(output_types), std::span(output_weights), -1, 0.0f, -1);
+                             std::span(output_types), std::span(output_weights), std::span(output_edge_ts), -1, 0.0f,
+                             -1);
     EXPECT_EQ(output_types, std::vector<snark::Type>(6, -1));
     EXPECT_EQ(output_nodes, std::vector<snark::NodeId>(6, -1));
     EXPECT_EQ(output_weights, std::vector<float>(6, 0));
+    EXPECT_EQ(output_edge_ts, std::vector<snark::Timestamp>(6, snark::PLACEHOLDER_TIMESTAMP));
 }
 
 TEST(DistributedTest, UniformSampleNeighborsMultipleServers)
@@ -648,10 +660,12 @@ TEST(DistributedTest, UniformSampleNeighborsMultipleServers)
     const size_t nb_count = 2;
     std::vector<snark::NodeId> output_nodes(nb_count * input_nodes.size());
     std::vector<snark::Type> output_types(nb_count * input_nodes.size(), -1);
+    std::vector<snark::Timestamp> output_edge_ts(nb_count * input_nodes.size(), -3);
     c.UniformSampleNeighbor(false, 23, std::span(input_nodes), std::span(input_types), {}, nb_count,
-                            std::span(output_nodes), std::span(output_types), -1, -1);
+                            std::span(output_nodes), std::span(output_types), std::span(output_edge_ts), -1, -1);
     EXPECT_EQ(output_types, std::vector<snark::Type>({0, 0, 0, 0, 0, 0}));
     EXPECT_EQ(output_nodes, std::vector<snark::NodeId>({2, 2, 57, 56, 80, 81}));
+    EXPECT_EQ(output_edge_ts, std::vector<snark::Timestamp>(6, snark::PLACEHOLDER_TIMESTAMP));
 }
 
 TEST(DistributedTest, UniformSampleNeighborsWithoutReplacementMultipleServers)
@@ -664,10 +678,12 @@ TEST(DistributedTest, UniformSampleNeighborsWithoutReplacementMultipleServers)
     const size_t nb_count = 2;
     std::vector<snark::NodeId> output_nodes(nb_count * input_nodes.size());
     std::vector<snark::Type> output_types(nb_count * input_nodes.size(), -1);
+    std::vector<snark::Timestamp> output_edge_ts(nb_count * input_nodes.size(), -2);
     c.UniformSampleNeighbor(true, 23, std::span(input_nodes), std::span(input_types), {}, nb_count,
-                            std::span(output_nodes), std::span(output_types), -1, -1);
+                            std::span(output_nodes), std::span(output_types), std::span(output_edge_ts), -1, -1);
     EXPECT_EQ(output_types, std::vector<snark::Type>({0, 0, 0, 0, 0, 0}));
-    EXPECT_EQ(output_nodes, std::vector<snark::NodeId>({2, 4, 59, 57, 81, 79}));
+    EXPECT_EQ(output_nodes, std::vector<snark::NodeId>({3, 2, 58, 57, 80, 79}));
+    EXPECT_EQ(output_edge_ts, std::vector<snark::Timestamp>(6, snark::PLACEHOLDER_TIMESTAMP));
 }
 
 TEST(DistributedTest, NeighborCountMultipleServers)
@@ -864,12 +880,14 @@ TEST(DistributedTest, FullNeighborsMultipleTypesMultipleServers)
     std::vector<snark::Type> output_types;
     std::vector<float> output_weights;
     std::vector<uint64_t> output_counts(input_nodes.size());
+    std::vector<snark::Timestamp> output_edge_ts;
     c.FullNeighbor(std::span(input_nodes), std::span(input_types), {}, output_nodes, output_types, output_weights,
-                   std::span(output_counts));
+                   output_edge_ts, std::span(output_counts));
     EXPECT_EQ(output_types, std::vector<snark::Type>({0, 1, 1}));
     EXPECT_EQ(output_nodes, std::vector<snark::NodeId>({1, 2, 3}));
     EXPECT_EQ(output_weights, std::vector<float>({1, 2, 1}));
     EXPECT_EQ(output_counts, std::vector<uint64_t>({3}));
+    EXPECT_EQ(output_edge_ts, std::vector<snark::Timestamp>(3, snark::PLACEHOLDER_TIMESTAMP));
 }
 
 TEST(DistributedTest, FullNeighborsMultipleServers)
@@ -883,12 +901,14 @@ TEST(DistributedTest, FullNeighborsMultipleServers)
     std::vector<snark::Type> output_types;
     std::vector<float> output_weights;
     std::vector<uint64_t> output_counts(input_nodes.size());
+    std::vector<snark::Timestamp> output_edge_ts;
     c.FullNeighbor(std::span(input_nodes), std::span(input_types), {}, output_nodes, output_types, output_weights,
-                   std::span(output_counts));
+                   output_edge_ts, std::span(output_counts));
     EXPECT_EQ(output_types, std::vector<snark::Type>({0, 0, 0, 0, 0, 0, 0, 0}));
     EXPECT_EQ(output_nodes, std::vector<snark::NodeId>({1, 2, 3, 4, 56, 57, 58, 59}));
     EXPECT_EQ(output_weights, std::vector<float>({1, 2, 1, 2, 1, 2, 1, 2}));
     EXPECT_EQ(output_counts, std::vector<uint64_t>({4, 4}));
+    EXPECT_EQ(output_edge_ts, std::vector<snark::Timestamp>(8, snark::PLACEHOLDER_TIMESTAMP));
 }
 
 std::pair<ServerList, std::shared_ptr<snark::GRPCClient>> CreateMultiServerSplitFeaturesEnvironment(

--- a/src/cc/tests/distributed_test.cc
+++ b/src/cc/tests/distributed_test.cc
@@ -529,7 +529,7 @@ TEST(DistributedTest, SampleNeighborsSingleServer)
     std::vector<float> output_weights(nb_count * input_nodes.size());
     std::vector<snark::Type> output_types(nb_count * input_nodes.size(), -1);
     std::vector<snark::Timestamp> output_edge_ts(nb_count * input_nodes.size(), -6);
-    client.WeightedSampleNeighbor(21, std::span(input_nodes), std::span(input_types), {}, nb_count,
+    client.WeightedSampleNeighbor(true, 21, std::span(input_nodes), std::span(input_types), {}, nb_count,
                                   std::span(output_nodes), std::span(output_types), std::span(output_weights),
                                   std::span(output_edge_ts), -1, 0.0f, -1);
     EXPECT_EQ(output_types, std::vector<snark::Type>(6, 0));
@@ -548,7 +548,7 @@ TEST(DistributedTest, UniformSampleNeighborsSingleServer)
     std::vector<snark::NodeId> output_nodes(nb_count * input_nodes.size());
     std::vector<snark::Type> output_types(nb_count * input_nodes.size(), -1);
     std::vector<snark::Timestamp> output_edge_ts(nb_count * input_nodes.size(), -5);
-    client.UniformSampleNeighbor(false, 21, std::span(input_nodes), std::span(input_types), {}, nb_count,
+    client.UniformSampleNeighbor(false, true, 21, std::span(input_nodes), std::span(input_types), {}, nb_count,
                                  std::span(output_nodes), std::span(output_types), std::span(output_edge_ts), -1, -1);
     EXPECT_EQ(output_types, std::vector<snark::Type>({0, 0, 0, 0, 0, 0}));
     EXPECT_EQ(output_nodes, std::vector<snark::NodeId>({3, 3, 5, 2, 4, 4}));
@@ -565,7 +565,7 @@ TEST(DistributedTest, UniformSampleNeighborsWithoutReplacementSingleServer)
     std::vector<snark::NodeId> output_nodes(nb_count * input_nodes.size());
     std::vector<snark::Type> output_types(nb_count * input_nodes.size(), -1);
     std::vector<snark::Timestamp> output_edge_ts(nb_count * input_nodes.size(), -2);
-    client.UniformSampleNeighbor(true, 21, std::span(input_nodes), std::span(input_types), {}, nb_count,
+    client.UniformSampleNeighbor(true, true, 21, std::span(input_nodes), std::span(input_types), {}, nb_count,
                                  std::span(output_nodes), std::span(output_types), std::span(output_edge_ts), -1, -1);
     EXPECT_EQ(output_types, std::vector<snark::Type>({0, 0, 0, 0, 0, 0}));
     EXPECT_EQ(output_nodes, std::vector<snark::NodeId>({1, 4, 5, 4, 3, 5}));
@@ -620,9 +620,9 @@ TEST(DistributedTest, SampleNeighborsMultipleServers)
     std::vector<float> output_weights(nb_count * input_nodes.size());
     std::vector<snark::Type> output_types(nb_count * input_nodes.size(), -1);
     std::vector<snark::Timestamp> output_edge_ts(nb_count * input_nodes.size(), -4);
-    c.WeightedSampleNeighbor(23, std::span(input_nodes), std::span(input_types), {}, nb_count, std::span(output_nodes),
-                             std::span(output_types), std::span(output_weights), std::span(output_edge_ts), -1, 0.0f,
-                             -1);
+    c.WeightedSampleNeighbor(true, 23, std::span(input_nodes), std::span(input_types), {}, nb_count,
+                             std::span(output_nodes), std::span(output_types), std::span(output_weights),
+                             std::span(output_edge_ts), -1, 0.0f, -1);
     EXPECT_EQ(output_types, std::vector<snark::Type>(6, 0));
     EXPECT_EQ(output_nodes, std::vector<snark::NodeId>({2, 2, 57, 56, 80, 81}));
     EXPECT_EQ(output_weights, std::vector<float>({2, 2, 2, 1, 1, 2}));
@@ -641,9 +641,9 @@ TEST(DistributedTest, SampleNeighborsMultipleServersMissingNeighbors)
     std::vector<float> output_weights(nb_count * input_nodes.size());
     std::vector<snark::Type> output_types(nb_count * input_nodes.size(), -1);
     std::vector<snark::Timestamp> output_edge_ts(nb_count * input_nodes.size(), -2);
-    c.WeightedSampleNeighbor(23, std::span(input_nodes), std::span(input_types), {}, nb_count, std::span(output_nodes),
-                             std::span(output_types), std::span(output_weights), std::span(output_edge_ts), -1, 0.0f,
-                             -1);
+    c.WeightedSampleNeighbor(true, 23, std::span(input_nodes), std::span(input_types), {}, nb_count,
+                             std::span(output_nodes), std::span(output_types), std::span(output_weights),
+                             std::span(output_edge_ts), -1, 0.0f, -1);
     EXPECT_EQ(output_types, std::vector<snark::Type>(6, -1));
     EXPECT_EQ(output_nodes, std::vector<snark::NodeId>(6, -1));
     EXPECT_EQ(output_weights, std::vector<float>(6, 0));
@@ -661,7 +661,7 @@ TEST(DistributedTest, UniformSampleNeighborsMultipleServers)
     std::vector<snark::NodeId> output_nodes(nb_count * input_nodes.size());
     std::vector<snark::Type> output_types(nb_count * input_nodes.size(), -1);
     std::vector<snark::Timestamp> output_edge_ts(nb_count * input_nodes.size(), -3);
-    c.UniformSampleNeighbor(false, 23, std::span(input_nodes), std::span(input_types), {}, nb_count,
+    c.UniformSampleNeighbor(false, true, 23, std::span(input_nodes), std::span(input_types), {}, nb_count,
                             std::span(output_nodes), std::span(output_types), std::span(output_edge_ts), -1, -1);
     EXPECT_EQ(output_types, std::vector<snark::Type>({0, 0, 0, 0, 0, 0}));
     EXPECT_EQ(output_nodes, std::vector<snark::NodeId>({2, 2, 57, 56, 80, 81}));
@@ -679,7 +679,7 @@ TEST(DistributedTest, UniformSampleNeighborsWithoutReplacementMultipleServers)
     std::vector<snark::NodeId> output_nodes(nb_count * input_nodes.size());
     std::vector<snark::Type> output_types(nb_count * input_nodes.size(), -1);
     std::vector<snark::Timestamp> output_edge_ts(nb_count * input_nodes.size(), -2);
-    c.UniformSampleNeighbor(true, 23, std::span(input_nodes), std::span(input_types), {}, nb_count,
+    c.UniformSampleNeighbor(true, true, 23, std::span(input_nodes), std::span(input_types), {}, nb_count,
                             std::span(output_nodes), std::span(output_types), std::span(output_edge_ts), -1, -1);
     EXPECT_EQ(output_types, std::vector<snark::Type>({0, 0, 0, 0, 0, 0}));
     EXPECT_EQ(output_nodes, std::vector<snark::NodeId>({3, 2, 58, 57, 80, 79}));
@@ -881,7 +881,7 @@ TEST(DistributedTest, FullNeighborsMultipleTypesMultipleServers)
     std::vector<float> output_weights;
     std::vector<uint64_t> output_counts(input_nodes.size());
     std::vector<snark::Timestamp> output_edge_ts;
-    c.FullNeighbor(std::span(input_nodes), std::span(input_types), {}, output_nodes, output_types, output_weights,
+    c.FullNeighbor(true, std::span(input_nodes), std::span(input_types), {}, output_nodes, output_types, output_weights,
                    output_edge_ts, std::span(output_counts));
     EXPECT_EQ(output_types, std::vector<snark::Type>({0, 1, 1}));
     EXPECT_EQ(output_nodes, std::vector<snark::NodeId>({1, 2, 3}));
@@ -902,7 +902,7 @@ TEST(DistributedTest, FullNeighborsMultipleServers)
     std::vector<float> output_weights;
     std::vector<uint64_t> output_counts(input_nodes.size());
     std::vector<snark::Timestamp> output_edge_ts;
-    c.FullNeighbor(std::span(input_nodes), std::span(input_types), {}, output_nodes, output_types, output_weights,
+    c.FullNeighbor(true, std::span(input_nodes), std::span(input_types), {}, output_nodes, output_types, output_weights,
                    output_edge_ts, std::span(output_counts));
     EXPECT_EQ(output_types, std::vector<snark::Type>({0, 0, 0, 0, 0, 0, 0, 0}));
     EXPECT_EQ(output_nodes, std::vector<snark::NodeId>({1, 2, 3, 4, 56, 57, 58, 59}));

--- a/src/cc/tests/graph_test.cc
+++ b/src/cc/tests/graph_test.cc
@@ -92,7 +92,7 @@ TEST(GraphTest, UniformNodeSamplingSingleType)
     std::span input_nodes(nodes);
     std::span input_types(types);
     s.Sample(13, input_types, input_nodes);
-    EXPECT_EQ(nodes, std::vector<snark::NodeId>({0, 1, 2, 3, 10}));
+    EXPECT_EQ(nodes, std::vector<snark::NodeId>({0, 1, 2, 3, 5}));
     EXPECT_EQ(types, std::vector<snark::Type>(count, 0));
 }
 
@@ -172,7 +172,7 @@ void RandomNodeSamplingStatisticalProperties(std::pair<size_t, size_t> minmax_0,
         }
     }
     std::vector<snark::Type> types;
-    std::generate_n(std::back_inserter(types), num_types, [&types]() { return types.size(); });
+    std::generate_n(std::back_inserter(types), num_types, [&types]() { return snark::Type(types.size()); });
     std::vector<std::shared_ptr<UniformNodePartitionList<with_replacement>>> partitions;
     for (auto t : records)
     {
@@ -214,7 +214,7 @@ TEST(GraphTest, RandomNodeSamplingWithReplacementStatisticalProperties)
 
 TEST(GraphTest, RandomNodeSamplingWithoutReplacementStatisticalProperties)
 {
-    RandomNodeSamplingStatisticalProperties<false>({735, 863}, {740, 875});
+    RandomNodeSamplingStatisticalProperties<false>({745, 851}, {704, 874});
 }
 
 TEST(GraphTest, EdgeSamplingSingleType)
@@ -813,13 +813,15 @@ TEST_P(StorageTypeGraphTest, NeighborSamplesWithSingleNodeNoNeighbors)
     std::vector<snark::Type> neighbor_types(count * nodes.size(), -1);
     std::vector<float> neighbor_weights(count * nodes.size(), -1);
     std::vector<float> total_neighbor_weights(nodes.size());
+    std::vector<snark::Timestamp> edge_created_ts(count * nodes.size(), -2);
 
     g.SampleNeighbor(42, std::span(nodes), std::span(types), {}, count, std::span(neighbor_nodes),
-                     std::span(neighbor_types), std::span(neighbor_weights), std::span(total_neighbor_weights), 13, 2,
-                     -1);
+                     std::span(neighbor_types), std::span(neighbor_weights), std::span(total_neighbor_weights),
+                     std::span(edge_created_ts), 13, 2, -1);
     EXPECT_EQ(std::vector<snark::NodeId>(10, 13), neighbor_nodes);
     EXPECT_EQ(std::vector<snark::Type>(10, -1), neighbor_types);
     EXPECT_EQ(std::vector<float>(10, 2.0f), neighbor_weights);
+    EXPECT_EQ(std::vector<snark::Timestamp>(count * nodes.size(), snark::PLACEHOLDER_TIMESTAMP), edge_created_ts);
 }
 
 TEST(GraphTest, NeighborSampleSimple)
@@ -849,14 +851,16 @@ TEST(GraphTest, NeighborSampleSimple)
     std::vector<snark::Type> neighbor_types(count * nodes.size(), -1);
     std::vector<float> neighbor_weights(count * nodes.size(), -1);
     std::vector<float> total_neighbor_weights(nodes.size());
+    std::vector<snark::Timestamp> edge_created_ts(count * nodes.size(), -2);
 
     g.SampleNeighbor(42, std::span(nodes), std::span(types), {}, count, std::span(neighbor_nodes),
-                     std::span(neighbor_types), std::span(neighbor_weights), std::span(total_neighbor_weights), 0, 0,
-                     -1);
+                     std::span(neighbor_types), std::span(neighbor_weights), std::span(total_neighbor_weights),
+                     std::span(edge_created_ts), 0, 0, -1);
 
     EXPECT_EQ(std::vector<snark::NodeId>({4, 1, 3, 6, 6, 8}), neighbor_nodes);
     EXPECT_EQ(std::vector<snark::Type>(6, 0), neighbor_types);
     EXPECT_EQ(std::vector<float>(6, 1), neighbor_weights);
+    EXPECT_EQ(std::vector<snark::Timestamp>(count * nodes.size(), snark::PLACEHOLDER_TIMESTAMP), edge_created_ts);
 }
 
 TEST_P(StorageTypeGraphTest, NeighborSampleMultipleTypesSinglePartition)
@@ -885,14 +889,16 @@ TEST_P(StorageTypeGraphTest, NeighborSampleMultipleTypesSinglePartition)
     std::vector<snark::Type> neighbor_types(count * nodes.size(), -1);
     std::vector<float> neighbor_weights(count * nodes.size(), -1);
     std::vector<float> total_neighbor_weights(nodes.size());
+    std::vector<snark::Timestamp> edge_created_ts(count * nodes.size(), -2);
 
     g.SampleNeighbor(42, std::span(nodes), std::span(types), {}, count, std::span(neighbor_nodes),
-                     std::span(neighbor_types), std::span(neighbor_weights), std::span(total_neighbor_weights), 0, 0,
-                     -1);
+                     std::span(neighbor_types), std::span(neighbor_weights), std::span(total_neighbor_weights),
+                     std::span(edge_created_ts), 0, 0, -1);
 
     EXPECT_EQ(std::vector<snark::NodeId>({5, 1, 3, 7, 7, 8}), neighbor_nodes);
     EXPECT_EQ(std::vector<snark::Type>(6, 0), neighbor_types);
     EXPECT_EQ(std::vector<float>(6, 1.f), neighbor_weights);
+    EXPECT_EQ(std::vector<snark::Timestamp>(count * nodes.size(), snark::PLACEHOLDER_TIMESTAMP), edge_created_ts);
 }
 
 TEST(GraphTest, NeighborSampleMultipleTypesMultiplePartitions)
@@ -925,13 +931,15 @@ TEST(GraphTest, NeighborSampleMultipleTypesMultiplePartitions)
     std::vector<snark::Type> neighbor_types(count * nodes.size(), -1);
     std::vector<float> neighbor_weights(count * nodes.size(), -1);
     std::vector<float> total_neighbor_weights(nodes.size());
+    std::vector<snark::Timestamp> edge_created_ts(count * nodes.size(), -2);
 
     g.SampleNeighbor(8, std::span(nodes), std::span(types), {}, count, std::span(neighbor_nodes),
-                     std::span(neighbor_types), std::span(neighbor_weights), std::span(total_neighbor_weights), 0, 0,
-                     0);
+                     std::span(neighbor_types), std::span(neighbor_weights), std::span(total_neighbor_weights),
+                     std::span(edge_created_ts), 0, 0, 0);
     EXPECT_EQ(std::vector<snark::NodeId>({1, 1, 4, 6}), neighbor_nodes);
     EXPECT_EQ(std::vector<snark::Type>({0, 0, 0, 1}), neighbor_types);
     EXPECT_EQ(std::vector<float>({1.f, 1.f, 3.f, 2.0f}), neighbor_weights);
+    EXPECT_EQ(std::vector<snark::Timestamp>(count * nodes.size(), snark::PLACEHOLDER_TIMESTAMP), edge_created_ts);
 }
 
 TEST(GraphTest, NeighborSampleMultipleTypesNeighborsSpreadAcrossPartitions)
@@ -964,14 +972,16 @@ TEST(GraphTest, NeighborSampleMultipleTypesNeighborsSpreadAcrossPartitions)
     std::vector<snark::Type> neighbor_types(count * nodes.size(), -1);
     std::vector<float> neighbor_weights(count * nodes.size(), -1);
     std::vector<float> total_neighbor_weights(nodes.size());
+    std::vector<snark::Timestamp> edge_created_ts(count * nodes.size(), -2);
 
     g.SampleNeighbor(13, std::span(nodes), std::span(types), {}, count, std::span(neighbor_nodes),
-                     std::span(neighbor_types), std::span(neighbor_weights), std::span(total_neighbor_weights), 0, 0,
-                     0);
+                     std::span(neighbor_types), std::span(neighbor_weights), std::span(total_neighbor_weights),
+                     std::span(edge_created_ts), 0, 0, 0);
 
     EXPECT_EQ(std::vector<snark::NodeId>({7, 7, 7, 7, 3, 5}), neighbor_nodes);
     EXPECT_EQ(std::vector<snark::Type>({1, 1, 1, 1, 0, 1}), neighbor_types);
     EXPECT_EQ(std::vector<float>({3.f, 3.f, 3.f, 3.f, 1.f, 1.f}), neighbor_weights);
+    EXPECT_EQ(std::vector<snark::Timestamp>(count * nodes.size(), snark::PLACEHOLDER_TIMESTAMP), edge_created_ts);
 }
 
 TEST(GraphTest, StatisticalNeighborSampleMultipleTypesNeighborsSpreadAcrossPartitions)
@@ -1003,6 +1013,7 @@ TEST(GraphTest, StatisticalNeighborSampleMultipleTypesNeighborsSpreadAcrossParti
     std::vector<snark::NodeId> neighbor_nodes(count * nodes.size(), -1);
     std::vector<snark::Type> neighbor_types(count, -1);
     std::vector<float> neighbor_weights(count * nodes.size(), -1);
+    std::vector<snark::Timestamp> edge_created_ts(count * nodes.size(), -2);
     snark::Xoroshiro128PlusGenerator gen(42);
     const size_t repetitions = 10000;
     boost::random::uniform_int_distribution<int64_t> seeds;
@@ -1011,8 +1022,8 @@ TEST(GraphTest, StatisticalNeighborSampleMultipleTypesNeighborsSpreadAcrossParti
     {
         std::fill(std::begin(total_neighbor_weights), std::end(total_neighbor_weights), 0);
         g.SampleNeighbor(seeds(gen), std::span(nodes), std::span(types), {}, count, std::span(neighbor_nodes),
-                         std::span(neighbor_types), std::span(neighbor_weights), std::span(total_neighbor_weights), 0,
-                         0, 0);
+                         std::span(neighbor_types), std::span(neighbor_weights), std::span(total_neighbor_weights),
+                         std::span(edge_created_ts), 0, 0, 0);
         for (auto n : neighbor_nodes)
         {
             if (n < 0)
@@ -1022,6 +1033,7 @@ TEST(GraphTest, StatisticalNeighborSampleMultipleTypesNeighborsSpreadAcrossParti
     }
 
     EXPECT_EQ(std::vector<size_t>({0, 0, 0, 0, 0, 9965, 9908, 10127, 0}), sample_counts);
+    EXPECT_EQ(std::vector<snark::Timestamp>(count * nodes.size(), snark::PLACEHOLDER_TIMESTAMP), edge_created_ts);
 }
 
 TEST(GraphTest, UniformNeighborSampleMultipleTypesNeighborsSpreadAcrossPartitions)
@@ -1052,11 +1064,14 @@ TEST(GraphTest, UniformNeighborSampleMultipleTypesNeighborsSpreadAcrossPartition
     std::vector<snark::NodeId> neighbor_nodes(count * nodes.size(), -1);
     std::vector<snark::Type> neighbor_types(count * nodes.size(), -1);
     std::vector<uint64_t> total_neighbor_counts(nodes.size());
+    std::vector<snark::Timestamp> edge_created_ts(count * nodes.size(), -2);
 
     g.UniformSampleNeighbor(true, 17, std::span(nodes), std::span(types), {}, count, std::span(neighbor_nodes),
-                            std::span(neighbor_types), std::span(total_neighbor_counts), 0, 2);
-    EXPECT_EQ(std::vector<snark::NodeId>({6, 5, 4, 7, 3, 0}), neighbor_nodes);
-    EXPECT_EQ(std::vector<snark::Type>({1, 1, 0, 1, 0, 2}), neighbor_types);
+                            std::span(neighbor_types), std::span(total_neighbor_counts), std::span(edge_created_ts), 0,
+                            2);
+    EXPECT_EQ(std::vector<snark::NodeId>({3, 4, 5, 6, 7, 0}), neighbor_nodes);
+    EXPECT_EQ(std::vector<snark::Type>({0, 0, 1, 1, 1, 2}), neighbor_types);
+    EXPECT_EQ(std::vector<snark::Timestamp>(count * nodes.size(), snark::PLACEHOLDER_TIMESTAMP), edge_created_ts);
 }
 
 TEST(GraphTest, NodeTypesMultipleTypesNeighborsSpreadAcrossPartitions)
@@ -1303,11 +1318,14 @@ TEST(GraphTest, UniformNeighborSampleMultipleTypesTriggerConditionalProbabilitie
     std::vector<snark::NodeId> neighbor_nodes(count * nodes.size(), -1);
     std::vector<snark::Type> neighbor_types(count * nodes.size(), -1);
     std::vector<uint64_t> total_neighbor_counts(nodes.size());
+    std::vector<snark::Timestamp> edge_created_ts(count * nodes.size(), -2);
 
     g.UniformSampleNeighbor(false, 3, std::span(nodes), std::span(types), {}, count, std::span(neighbor_nodes),
-                            std::span(neighbor_types), std::span(total_neighbor_counts), 0, 0);
+                            std::span(neighbor_types), std::span(total_neighbor_counts), std::span(edge_created_ts), 0,
+                            0);
     EXPECT_EQ(std::vector<snark::NodeId>({2, 3, 3, 7, 4, 2}), neighbor_nodes);
     EXPECT_EQ(std::vector<snark::Type>({0, 1, 1, 3, 1, 0}), neighbor_types);
+    EXPECT_EQ(std::vector<snark::Timestamp>(count * nodes.size(), snark::PLACEHOLDER_TIMESTAMP), edge_created_ts);
 }
 
 TEST(GraphTest, StatisticalUniformNeighborSampleSingleTypeNeighborSpreadAcrossPartitions)
@@ -1340,6 +1358,7 @@ TEST(GraphTest, StatisticalUniformNeighborSampleSingleTypeNeighborSpreadAcrossPa
     int count = 3;
     std::vector<snark::NodeId> neighbor_nodes(count * nodes.size(), -1);
     std::vector<snark::Type> neighbor_types(count * nodes.size(), -1);
+    std::vector<snark::Timestamp> edge_created_ts(count * nodes.size(), -2);
     snark::Xoroshiro128PlusGenerator gen(42);
     const size_t repetitions = 40000;
     boost::random::uniform_int_distribution<int64_t> seeds;
@@ -1349,7 +1368,8 @@ TEST(GraphTest, StatisticalUniformNeighborSampleSingleTypeNeighborSpreadAcrossPa
         std::fill(std::begin(total_neighbor_counts), std::end(total_neighbor_counts), 0);
         g.UniformSampleNeighbor(false, seeds(gen), std::span(nodes), std::span(types), {}, count,
                                 std::span(neighbor_nodes), std::span(neighbor_types), std::span(total_neighbor_counts),
-                                0, 0);
+                                std::span(edge_created_ts), 0, 0);
+        EXPECT_EQ(std::vector<snark::Timestamp>(count * nodes.size(), snark::PLACEHOLDER_TIMESTAMP), edge_created_ts);
         for (auto n : neighbor_nodes)
         {
             assert(n < 10 && n >= 0);
@@ -1357,21 +1377,23 @@ TEST(GraphTest, StatisticalUniformNeighborSampleSingleTypeNeighborSpreadAcrossPa
         }
     }
 
-    EXPECT_EQ(std::vector<size_t>({0, 0, 0, 0, 0, 30063, 29904, 30085, 29948, 0}), sample_counts);
+    EXPECT_EQ(std::vector<size_t>({0, 0, 0, 0, 0, 30064, 29993, 29985, 29958, 0}), sample_counts);
     std::fill(std::begin(sample_counts), std::end(sample_counts), 0);
     for (size_t i = 0; i < repetitions; ++i)
     {
         std::fill(std::begin(total_neighbor_counts), std::end(total_neighbor_counts), 0);
         g.UniformSampleNeighbor(true, seeds(gen), std::span(nodes), std::span(types), {}, count,
                                 std::span(neighbor_nodes), std::span(neighbor_types), std::span(total_neighbor_counts),
-                                0, 0);
+                                std::span(edge_created_ts), 0, 0);
         for (auto n : neighbor_nodes)
         {
             ++sample_counts[n];
         }
+
+        EXPECT_EQ(std::vector<snark::Timestamp>(count * nodes.size(), snark::PLACEHOLDER_TIMESTAMP), edge_created_ts);
     }
 
-    EXPECT_EQ(std::vector<size_t>({0, 0, 0, 0, 0, 30011, 30107, 29858, 30024, 0}), sample_counts);
+    EXPECT_EQ(std::vector<size_t>({0, 0, 0, 0, 0, 30031, 30073, 29965, 29931, 0}), sample_counts);
 }
 
 TEST(GraphTest, StatisticalUniformNeighborSampleMultipleTypesNeighborsSpreadAcrossPartitions)
@@ -1392,7 +1414,7 @@ TEST(GraphTest, StatisticalUniformNeighborSampleMultipleTypesNeighborsSpreadAcro
         .m_id = 1,
         .m_type = 1,
         .m_neighbors{std::vector<TestGraph::NeighborRecord>{{7, 1, 1.0f}, {8, 1, 1.0f}, {9, 1, 1.0f}}}});
-    auto path = std::filesystem::path(::testing::UnitTest::GetInstance()->current_test_info()->name());
+    auto path = std::filesystem::path(testing::UnitTest::GetInstance()->current_test_info()->name());
     assert(std::filesystem::create_directories(path));
     TestGraph::convert(path, "0_0", std::move(m1), 2);
     TestGraph::convert(path, "1_0", std::move(m2), 2);
@@ -1404,6 +1426,7 @@ TEST(GraphTest, StatisticalUniformNeighborSampleMultipleTypesNeighborsSpreadAcro
     int count = 2;
     std::vector<snark::NodeId> neighbor_nodes(count * nodes.size(), -1);
     std::vector<snark::Type> neighbor_types(count * nodes.size(), -1);
+    std::vector<snark::Timestamp> edge_created_ts(count * nodes.size(), -2);
     snark::Xoroshiro128PlusGenerator gen(23);
     const size_t repetitions = 40000;
     boost::random::uniform_int_distribution<int64_t> seeds;
@@ -1413,28 +1436,31 @@ TEST(GraphTest, StatisticalUniformNeighborSampleMultipleTypesNeighborsSpreadAcro
         std::fill(std::begin(total_neighbor_counts), std::end(total_neighbor_counts), 0);
         g.UniformSampleNeighbor(false, seeds(gen), std::span(nodes), std::span(types), {}, count,
                                 std::span(neighbor_nodes), std::span(neighbor_types), std::span(total_neighbor_counts),
-                                0, 0);
+                                std::span(edge_created_ts), 0, 0);
+        EXPECT_EQ(std::vector<snark::Timestamp>(count * nodes.size(), snark::PLACEHOLDER_TIMESTAMP), edge_created_ts);
         for (auto n : neighbor_nodes)
         {
             ++sample_counts[n];
         }
     }
 
-    EXPECT_EQ(std::vector<size_t>({0, 0, 0, 11684, 11256, 11449, 11355, 11404, 11328, 11524}), sample_counts);
+    EXPECT_EQ(std::vector<size_t>({0, 0, 0, 11582, 11334, 11389, 11404, 11320, 11414, 11557}), sample_counts);
+    std::fill(std::begin(neighbor_types), std::end(neighbor_types), -2);
     std::fill(std::begin(sample_counts), std::end(sample_counts), 0);
     for (size_t i = 0; i < repetitions; ++i)
     {
         std::fill(std::begin(total_neighbor_counts), std::end(total_neighbor_counts), 0);
         g.UniformSampleNeighbor(true, seeds(gen), std::span(nodes), std::span(types), {}, count,
                                 std::span(neighbor_nodes), std::span(neighbor_types), std::span(total_neighbor_counts),
-                                0, 0);
+                                std::span(edge_created_ts), 0, 0);
+        EXPECT_EQ(std::vector<snark::Timestamp>(count * nodes.size(), snark::PLACEHOLDER_TIMESTAMP), edge_created_ts);
         for (auto n : neighbor_nodes)
         {
             ++sample_counts[n];
         }
     }
 
-    EXPECT_EQ(std::vector<size_t>({0, 0, 0, 11311, 11501, 11408, 11423, 11477, 11358, 11522}), sample_counts);
+    EXPECT_EQ(std::vector<size_t>({0, 0, 0, 11370, 11456, 11391, 11654, 11195, 11435, 11499}), sample_counts);
 }
 
 TEST(GraphTest, GetNeighborsMultipleTypesNeighborsSpreadAcrossPartitions)
@@ -1464,14 +1490,16 @@ TEST(GraphTest, GetNeighborsMultipleTypesNeighborsSpreadAcrossPartitions)
     std::vector<snark::NodeId> neighbor_nodes;
     std::vector<snark::Type> neighbor_types;
     std::vector<float> neighbor_weights;
+    std::vector<snark::Timestamp> edge_created_ts;
     std::vector<uint64_t> neighbor_counts(nodes.size());
 
     g.FullNeighbor(std::span(nodes), std::span(types), {}, neighbor_nodes, neighbor_types, neighbor_weights,
-                   std::span(neighbor_counts));
+                   edge_created_ts, std::span(neighbor_counts));
     EXPECT_EQ(std::vector<snark::NodeId>({1, 2, 3, 4, 5, 6, 7}), neighbor_nodes);
     EXPECT_EQ(std::vector<snark::Type>({0, 0, 0, 0, 1, 1, 1}), neighbor_types);
     EXPECT_EQ(std::vector<uint64_t>({2, 5, 0}), neighbor_counts);
     EXPECT_EQ(std::vector<float>({1.f, 1.f, 1.f, 1.f, 1.f, 1.5f, 3.f}), neighbor_weights);
+    EXPECT_EQ(std::vector<snark::Timestamp>(7, snark::PLACEHOLDER_TIMESTAMP), edge_created_ts);
 }
 
 TEST(GraphTest, GetNodeTypesAcrossPartitions)

--- a/src/cc/tests/graph_test.cc
+++ b/src/cc/tests/graph_test.cc
@@ -815,7 +815,7 @@ TEST_P(StorageTypeGraphTest, NeighborSamplesWithSingleNodeNoNeighbors)
     std::vector<float> total_neighbor_weights(nodes.size());
     std::vector<snark::Timestamp> edge_created_ts(count * nodes.size(), -2);
 
-    g.SampleNeighbor(42, std::span(nodes), std::span(types), {}, count, std::span(neighbor_nodes),
+    g.SampleNeighbor(true, 42, std::span(nodes), std::span(types), {}, count, std::span(neighbor_nodes),
                      std::span(neighbor_types), std::span(neighbor_weights), std::span(total_neighbor_weights),
                      std::span(edge_created_ts), 13, 2, -1);
     EXPECT_EQ(std::vector<snark::NodeId>(10, 13), neighbor_nodes);
@@ -853,7 +853,7 @@ TEST(GraphTest, NeighborSampleSimple)
     std::vector<float> total_neighbor_weights(nodes.size());
     std::vector<snark::Timestamp> edge_created_ts(count * nodes.size(), -2);
 
-    g.SampleNeighbor(42, std::span(nodes), std::span(types), {}, count, std::span(neighbor_nodes),
+    g.SampleNeighbor(true, 42, std::span(nodes), std::span(types), {}, count, std::span(neighbor_nodes),
                      std::span(neighbor_types), std::span(neighbor_weights), std::span(total_neighbor_weights),
                      std::span(edge_created_ts), 0, 0, -1);
 
@@ -891,7 +891,7 @@ TEST_P(StorageTypeGraphTest, NeighborSampleMultipleTypesSinglePartition)
     std::vector<float> total_neighbor_weights(nodes.size());
     std::vector<snark::Timestamp> edge_created_ts(count * nodes.size(), -2);
 
-    g.SampleNeighbor(42, std::span(nodes), std::span(types), {}, count, std::span(neighbor_nodes),
+    g.SampleNeighbor(true, 42, std::span(nodes), std::span(types), {}, count, std::span(neighbor_nodes),
                      std::span(neighbor_types), std::span(neighbor_weights), std::span(total_neighbor_weights),
                      std::span(edge_created_ts), 0, 0, -1);
 
@@ -933,7 +933,7 @@ TEST(GraphTest, NeighborSampleMultipleTypesMultiplePartitions)
     std::vector<float> total_neighbor_weights(nodes.size());
     std::vector<snark::Timestamp> edge_created_ts(count * nodes.size(), -2);
 
-    g.SampleNeighbor(8, std::span(nodes), std::span(types), {}, count, std::span(neighbor_nodes),
+    g.SampleNeighbor(true, 8, std::span(nodes), std::span(types), {}, count, std::span(neighbor_nodes),
                      std::span(neighbor_types), std::span(neighbor_weights), std::span(total_neighbor_weights),
                      std::span(edge_created_ts), 0, 0, 0);
     EXPECT_EQ(std::vector<snark::NodeId>({1, 1, 4, 6}), neighbor_nodes);
@@ -974,7 +974,7 @@ TEST(GraphTest, NeighborSampleMultipleTypesNeighborsSpreadAcrossPartitions)
     std::vector<float> total_neighbor_weights(nodes.size());
     std::vector<snark::Timestamp> edge_created_ts(count * nodes.size(), -2);
 
-    g.SampleNeighbor(13, std::span(nodes), std::span(types), {}, count, std::span(neighbor_nodes),
+    g.SampleNeighbor(true, 13, std::span(nodes), std::span(types), {}, count, std::span(neighbor_nodes),
                      std::span(neighbor_types), std::span(neighbor_weights), std::span(total_neighbor_weights),
                      std::span(edge_created_ts), 0, 0, 0);
 
@@ -1021,7 +1021,7 @@ TEST(GraphTest, StatisticalNeighborSampleMultipleTypesNeighborsSpreadAcrossParti
     for (size_t i = 0; i < repetitions; ++i)
     {
         std::fill(std::begin(total_neighbor_weights), std::end(total_neighbor_weights), 0);
-        g.SampleNeighbor(seeds(gen), std::span(nodes), std::span(types), {}, count, std::span(neighbor_nodes),
+        g.SampleNeighbor(true, seeds(gen), std::span(nodes), std::span(types), {}, count, std::span(neighbor_nodes),
                          std::span(neighbor_types), std::span(neighbor_weights), std::span(total_neighbor_weights),
                          std::span(edge_created_ts), 0, 0, 0);
         for (auto n : neighbor_nodes)
@@ -1066,7 +1066,7 @@ TEST(GraphTest, UniformNeighborSampleMultipleTypesNeighborsSpreadAcrossPartition
     std::vector<uint64_t> total_neighbor_counts(nodes.size());
     std::vector<snark::Timestamp> edge_created_ts(count * nodes.size(), -2);
 
-    g.UniformSampleNeighbor(true, 17, std::span(nodes), std::span(types), {}, count, std::span(neighbor_nodes),
+    g.UniformSampleNeighbor(true, true, 17, std::span(nodes), std::span(types), {}, count, std::span(neighbor_nodes),
                             std::span(neighbor_types), std::span(total_neighbor_counts), std::span(edge_created_ts), 0,
                             2);
     EXPECT_EQ(std::vector<snark::NodeId>({3, 4, 5, 6, 7, 0}), neighbor_nodes);
@@ -1320,7 +1320,7 @@ TEST(GraphTest, UniformNeighborSampleMultipleTypesTriggerConditionalProbabilitie
     std::vector<uint64_t> total_neighbor_counts(nodes.size());
     std::vector<snark::Timestamp> edge_created_ts(count * nodes.size(), -2);
 
-    g.UniformSampleNeighbor(false, 3, std::span(nodes), std::span(types), {}, count, std::span(neighbor_nodes),
+    g.UniformSampleNeighbor(false, true, 3, std::span(nodes), std::span(types), {}, count, std::span(neighbor_nodes),
                             std::span(neighbor_types), std::span(total_neighbor_counts), std::span(edge_created_ts), 0,
                             0);
     EXPECT_EQ(std::vector<snark::NodeId>({2, 3, 3, 7, 4, 2}), neighbor_nodes);
@@ -1366,7 +1366,7 @@ TEST(GraphTest, StatisticalUniformNeighborSampleSingleTypeNeighborSpreadAcrossPa
     for (size_t i = 0; i < repetitions; ++i)
     {
         std::fill(std::begin(total_neighbor_counts), std::end(total_neighbor_counts), 0);
-        g.UniformSampleNeighbor(false, seeds(gen), std::span(nodes), std::span(types), {}, count,
+        g.UniformSampleNeighbor(false, true, seeds(gen), std::span(nodes), std::span(types), {}, count,
                                 std::span(neighbor_nodes), std::span(neighbor_types), std::span(total_neighbor_counts),
                                 std::span(edge_created_ts), 0, 0);
         EXPECT_EQ(std::vector<snark::Timestamp>(count * nodes.size(), snark::PLACEHOLDER_TIMESTAMP), edge_created_ts);
@@ -1382,7 +1382,7 @@ TEST(GraphTest, StatisticalUniformNeighborSampleSingleTypeNeighborSpreadAcrossPa
     for (size_t i = 0; i < repetitions; ++i)
     {
         std::fill(std::begin(total_neighbor_counts), std::end(total_neighbor_counts), 0);
-        g.UniformSampleNeighbor(true, seeds(gen), std::span(nodes), std::span(types), {}, count,
+        g.UniformSampleNeighbor(true, true, seeds(gen), std::span(nodes), std::span(types), {}, count,
                                 std::span(neighbor_nodes), std::span(neighbor_types), std::span(total_neighbor_counts),
                                 std::span(edge_created_ts), 0, 0);
         for (auto n : neighbor_nodes)
@@ -1434,7 +1434,7 @@ TEST(GraphTest, StatisticalUniformNeighborSampleMultipleTypesNeighborsSpreadAcro
     for (size_t i = 0; i < repetitions; ++i)
     {
         std::fill(std::begin(total_neighbor_counts), std::end(total_neighbor_counts), 0);
-        g.UniformSampleNeighbor(false, seeds(gen), std::span(nodes), std::span(types), {}, count,
+        g.UniformSampleNeighbor(false, true, seeds(gen), std::span(nodes), std::span(types), {}, count,
                                 std::span(neighbor_nodes), std::span(neighbor_types), std::span(total_neighbor_counts),
                                 std::span(edge_created_ts), 0, 0);
         EXPECT_EQ(std::vector<snark::Timestamp>(count * nodes.size(), snark::PLACEHOLDER_TIMESTAMP), edge_created_ts);
@@ -1450,7 +1450,7 @@ TEST(GraphTest, StatisticalUniformNeighborSampleMultipleTypesNeighborsSpreadAcro
     for (size_t i = 0; i < repetitions; ++i)
     {
         std::fill(std::begin(total_neighbor_counts), std::end(total_neighbor_counts), 0);
-        g.UniformSampleNeighbor(true, seeds(gen), std::span(nodes), std::span(types), {}, count,
+        g.UniformSampleNeighbor(true, true, seeds(gen), std::span(nodes), std::span(types), {}, count,
                                 std::span(neighbor_nodes), std::span(neighbor_types), std::span(total_neighbor_counts),
                                 std::span(edge_created_ts), 0, 0);
         EXPECT_EQ(std::vector<snark::Timestamp>(count * nodes.size(), snark::PLACEHOLDER_TIMESTAMP), edge_created_ts);
@@ -1493,7 +1493,7 @@ TEST(GraphTest, GetNeighborsMultipleTypesNeighborsSpreadAcrossPartitions)
     std::vector<snark::Timestamp> edge_created_ts;
     std::vector<uint64_t> neighbor_counts(nodes.size());
 
-    g.FullNeighbor(std::span(nodes), std::span(types), {}, neighbor_nodes, neighbor_types, neighbor_weights,
+    g.FullNeighbor(true, std::span(nodes), std::span(types), {}, neighbor_nodes, neighbor_types, neighbor_weights,
                    edge_created_ts, std::span(neighbor_counts));
     EXPECT_EQ(std::vector<snark::NodeId>({1, 2, 3, 4, 5, 6, 7}), neighbor_nodes);
     EXPECT_EQ(std::vector<snark::Type>({0, 0, 0, 0, 1, 1, 1}), neighbor_types);

--- a/src/cc/tests/hdfs_test.cc
+++ b/src/cc/tests/hdfs_test.cc
@@ -119,7 +119,7 @@ TEST(HDFSTest, NeighborSample)
     std::vector<float> total_neighbor_weights(nodes.size());
     std::vector<snark::Timestamp> neighbor_ts(count * nodes.size(), -2);
 
-    g.SampleNeighbor(42, std::span(nodes), std::span(types), {}, count, std::span(neighbor_nodes),
+    g.SampleNeighbor(true, 42, std::span(nodes), std::span(types), {}, count, std::span(neighbor_nodes),
                      std::span(neighbor_types), std::span(neighbor_weights), std::span(total_neighbor_weights),
                      std::span(neighbor_ts), 0, 0, -1);
     EXPECT_EQ(std::vector<snark::NodeId>({5, 1, 3, 7, 7, 8}), neighbor_nodes);

--- a/src/cc/tests/hdfs_test.cc
+++ b/src/cc/tests/hdfs_test.cc
@@ -117,13 +117,15 @@ TEST(HDFSTest, NeighborSample)
     std::vector<snark::Type> neighbor_types(count * nodes.size(), -1);
     std::vector<float> neighbor_weights(count * nodes.size(), -1);
     std::vector<float> total_neighbor_weights(nodes.size());
+    std::vector<snark::Timestamp> neighbor_ts(count * nodes.size(), -2);
 
     g.SampleNeighbor(42, std::span(nodes), std::span(types), {}, count, std::span(neighbor_nodes),
-                     std::span(neighbor_types), std::span(neighbor_weights), std::span(total_neighbor_weights), 0, 0,
-                     -1);
+                     std::span(neighbor_types), std::span(neighbor_weights), std::span(total_neighbor_weights),
+                     std::span(neighbor_ts), 0, 0, -1);
     EXPECT_EQ(std::vector<snark::NodeId>({5, 1, 3, 7, 7, 8}), neighbor_nodes);
     EXPECT_EQ(std::vector<snark::Type>(6, 0), neighbor_types);
     EXPECT_EQ(std::vector<float>(6, 1), neighbor_weights);
+    EXPECT_EQ(std::vector<snark::Timestamp>(6, snark::PLACEHOLDER_TIMESTAMP), neighbor_ts);
 }
 
 TEST(HDFSTest, EdgeFeatureNoFeature)

--- a/src/cc/tests/temporal_test.cc
+++ b/src/cc/tests/temporal_test.cc
@@ -192,7 +192,7 @@ TEST_F(TemporalTest, GetFullNeighborSinglePartition)
     std::vector<snark::Type> output_neighbor_types;
     std::vector<float> output_neighbors_weights;
     std::vector<snark::Timestamp> output_edge_created_ts;
-    m_single_partition_graph->FullNeighbor(std::span(nodes), std::span(types), std::span(ts), output_neighbor_ids,
+    m_single_partition_graph->FullNeighbor(true, std::span(nodes), std::span(types), std::span(ts), output_neighbor_ids,
                                            output_neighbor_types, output_neighbors_weights, output_edge_created_ts,
                                            std::span(output_neighbors_count));
     EXPECT_TRUE(output_neighbor_ids.empty());
@@ -202,7 +202,7 @@ TEST_F(TemporalTest, GetFullNeighborSinglePartition)
     EXPECT_EQ(std::vector<uint64_t>({0, 0}), output_neighbors_count);
 
     ts = {0, 0};
-    m_single_partition_graph->FullNeighbor(std::span(nodes), std::span(types), std::span(ts), output_neighbor_ids,
+    m_single_partition_graph->FullNeighbor(true, std::span(nodes), std::span(types), std::span(ts), output_neighbor_ids,
                                            output_neighbor_types, output_neighbors_weights, output_edge_created_ts,
                                            std::span(output_neighbors_count));
     EXPECT_EQ(std::vector<snark::NodeId>({1, 2, 3}), output_neighbor_ids);
@@ -219,7 +219,7 @@ TEST_F(TemporalTest, GetFullNeighborSinglePartition)
     // Check for different singe edge type filter
     types = {1};
     ts = {2, 2};
-    m_single_partition_graph->FullNeighbor(std::span(nodes), std::span(types), std::span(ts), output_neighbor_ids,
+    m_single_partition_graph->FullNeighbor(true, std::span(nodes), std::span(types), std::span(ts), output_neighbor_ids,
                                            output_neighbor_types, output_neighbors_weights, output_edge_created_ts,
                                            std::span(output_neighbors_count));
     EXPECT_EQ(std::vector<snark::NodeId>({5}), output_neighbor_ids);
@@ -235,7 +235,7 @@ TEST_F(TemporalTest, GetFullNeighborSinglePartition)
 
     // Check for both edge types
     types = {0, 1};
-    m_single_partition_graph->FullNeighbor(std::span(nodes), std::span(types), std::span(ts), output_neighbor_ids,
+    m_single_partition_graph->FullNeighbor(true, std::span(nodes), std::span(types), std::span(ts), output_neighbor_ids,
                                            output_neighbor_types, output_neighbors_weights, output_edge_created_ts,
                                            std::span(output_neighbors_count));
     EXPECT_EQ(std::vector<snark::NodeId>({5}), output_neighbor_ids);
@@ -253,7 +253,7 @@ TEST_F(TemporalTest, GetFullNeighborSinglePartition)
     types = {-1, 100};
     std::fill_n(output_neighbors_count.begin(), 2, -1);
 
-    m_single_partition_graph->FullNeighbor(std::span(nodes), std::span(types), std::span(ts), output_neighbor_ids,
+    m_single_partition_graph->FullNeighbor(true, std::span(nodes), std::span(types), std::span(ts), output_neighbor_ids,
                                            output_neighbor_types, output_neighbors_weights, output_edge_created_ts,
                                            std::span(output_neighbors_count));
     EXPECT_TRUE(output_neighbor_ids.empty());
@@ -267,7 +267,7 @@ TEST_F(TemporalTest, GetFullNeighborSinglePartition)
     types = {0, 1};
     std::fill_n(output_neighbors_count.begin(), 2, -1);
 
-    m_single_partition_graph->FullNeighbor(std::span(nodes), std::span(types), std::span(ts), output_neighbor_ids,
+    m_single_partition_graph->FullNeighbor(true, std::span(nodes), std::span(types), std::span(ts), output_neighbor_ids,
                                            output_neighbor_types, output_neighbors_weights, output_edge_created_ts,
                                            std::span(output_neighbors_count));
     EXPECT_TRUE(output_neighbor_ids.empty());
@@ -323,7 +323,7 @@ TEST_F(TemporalTest, GetFullNeighborMultiplePartitions)
     std::vector<snark::Type> output_neighbor_types;
     std::vector<float> output_neighbors_weights;
     std::vector<snark::Timestamp> output_edge_created_ts;
-    m_multi_partition_graph->FullNeighbor(std::span(nodes), std::span(types), std::span(ts), output_neighbor_ids,
+    m_multi_partition_graph->FullNeighbor(true, std::span(nodes), std::span(types), std::span(ts), output_neighbor_ids,
                                           output_neighbor_types, output_neighbors_weights, output_edge_created_ts,
                                           std::span(output_neighbors_count));
     EXPECT_EQ(std::vector<snark::NodeId>({5, 7}), output_neighbor_ids);
@@ -339,7 +339,7 @@ TEST_F(TemporalTest, GetFullNeighborMultiplePartitions)
 
     // Check for multiple edge types
     types = {0, 1};
-    m_multi_partition_graph->FullNeighbor(std::span(nodes), std::span(types), std::span(ts), output_neighbor_ids,
+    m_multi_partition_graph->FullNeighbor(true, std::span(nodes), std::span(types), std::span(ts), output_neighbor_ids,
                                           output_neighbor_types, output_neighbors_weights, output_edge_created_ts,
                                           std::span(output_neighbors_count));
     EXPECT_EQ(std::vector<snark::NodeId>({4, 5, 7}), output_neighbor_ids);
@@ -356,7 +356,7 @@ TEST_F(TemporalTest, GetFullNeighborMultiplePartitions)
     // Check for different singe edge type filter
     types = {0};
     ts = {2, 2};
-    m_multi_partition_graph->FullNeighbor(std::span(nodes), std::span(types), std::span(ts), output_neighbor_ids,
+    m_multi_partition_graph->FullNeighbor(true, std::span(nodes), std::span(types), std::span(ts), output_neighbor_ids,
                                           output_neighbor_types, output_neighbors_weights, output_edge_created_ts,
                                           std::span(output_neighbors_count));
     EXPECT_EQ(std::vector<snark::NodeId>({4}), output_neighbor_ids);
@@ -374,7 +374,7 @@ TEST_F(TemporalTest, GetFullNeighborMultiplePartitions)
     types = {-1, 100};
     std::fill_n(output_neighbors_count.begin(), 2, -1);
 
-    m_multi_partition_graph->FullNeighbor(std::span(nodes), std::span(types), std::span(ts), output_neighbor_ids,
+    m_multi_partition_graph->FullNeighbor(true, std::span(nodes), std::span(types), std::span(ts), output_neighbor_ids,
                                           output_neighbor_types, output_neighbors_weights, output_edge_created_ts,
                                           std::span(output_neighbors_count));
     EXPECT_TRUE(output_neighbor_ids.empty());
@@ -388,7 +388,7 @@ TEST_F(TemporalTest, GetFullNeighborMultiplePartitions)
     types = {0, 1};
     std::fill_n(output_neighbors_count.begin(), 2, -1);
 
-    m_multi_partition_graph->FullNeighbor(std::span(nodes), std::span(types), std::span(ts), output_neighbor_ids,
+    m_multi_partition_graph->FullNeighbor(true, std::span(nodes), std::span(types), std::span(ts), output_neighbor_ids,
                                           output_neighbor_types, output_neighbors_weights, output_edge_created_ts,
                                           std::span(output_neighbors_count));
     EXPECT_TRUE(output_neighbor_ids.empty());
@@ -412,7 +412,7 @@ TEST_F(TemporalTest, GetSampleNeighborsMultiplePartitions)
     std::vector<float> output_neighbors_total_weights(nodes.size());
     std::vector<snark::Timestamp> output_edge_created_ts(sample_count * nodes.size(), -2);
     m_multi_partition_graph->SampleNeighbor(
-        33, std::span(nodes), std::span(types), std::span(ts), sample_count, std::span(output_neighbor_ids),
+        true, 33, std::span(nodes), std::span(types), std::span(ts), sample_count, std::span(output_neighbor_ids),
         std::span(output_neighbor_types), std::span(output_neighbors_weights),
         std::span(output_neighbors_total_weights), std::span(output_edge_created_ts), 42, 0.5f, 13);
 
@@ -432,7 +432,7 @@ TEST_F(TemporalTest, GetSampleNeighborsMultiplePartitions)
     // Check for multiple edge types
     types = {0, 1};
     m_multi_partition_graph->SampleNeighbor(
-        36, std::span(nodes), std::span(types), std::span(ts), sample_count, std::span(output_neighbor_ids),
+        true, 36, std::span(nodes), std::span(types), std::span(ts), sample_count, std::span(output_neighbor_ids),
         std::span(output_neighbor_types), std::span(output_neighbors_weights),
         std::span(output_neighbors_total_weights), std::span(output_edge_created_ts), 42, 0.5f, 13);
     EXPECT_EQ(std::vector<snark::NodeId>({42, 42, 7, 5}), output_neighbor_ids);
@@ -451,7 +451,7 @@ TEST_F(TemporalTest, GetSampleNeighborsMultiplePartitions)
     types = {1};
     ts = {0, 0};
     m_multi_partition_graph->SampleNeighbor(
-        37, std::span(nodes), std::span(types), std::span(ts), sample_count, std::span(output_neighbor_ids),
+        true, 37, std::span(nodes), std::span(types), std::span(ts), sample_count, std::span(output_neighbor_ids),
         std::span(output_neighbor_types), std::span(output_neighbors_weights),
         std::span(output_neighbors_total_weights), std::span(output_edge_created_ts), 42, 0.5f, 13);
     EXPECT_EQ(std::vector<snark::NodeId>({42, 42, 6, 6}), output_neighbor_ids);
@@ -470,7 +470,7 @@ TEST_F(TemporalTest, GetSampleNeighborsMultiplePartitions)
     types = {-1, 100};
 
     m_multi_partition_graph->SampleNeighbor(
-        33, std::span(nodes), std::span(types), std::span(ts), sample_count, std::span(output_neighbor_ids),
+        true, 33, std::span(nodes), std::span(types), std::span(ts), sample_count, std::span(output_neighbor_ids),
         std::span(output_neighbor_types), std::span(output_neighbors_weights),
         std::span(output_neighbors_total_weights), std::span(output_edge_created_ts), 42, 0.5f, 13);
     EXPECT_EQ(std::vector<snark::NodeId>({42, 42, 42, 42}), output_neighbor_ids);
@@ -489,7 +489,7 @@ TEST_F(TemporalTest, GetSampleNeighborsMultiplePartitions)
     types = {0, 1};
 
     m_multi_partition_graph->SampleNeighbor(
-        33, std::span(nodes), std::span(types), std::span(ts), sample_count, std::span(output_neighbor_ids),
+        true, 33, std::span(nodes), std::span(types), std::span(ts), sample_count, std::span(output_neighbor_ids),
         std::span(output_neighbor_types), std::span(output_neighbors_weights),
         std::span(output_neighbors_total_weights), std::span(output_edge_created_ts), 42, 0.5f, 13);
 
@@ -513,9 +513,9 @@ TEST_F(TemporalTest, GetUniformSampleNeighborMultiplePartitions)
     std::vector<uint64_t> output_neighbors_total_counts(nodes.size());
     std::vector<snark::Timestamp> output_edge_created_ts(sample_count * nodes.size(), -2);
     m_multi_partition_graph->UniformSampleNeighbor(
-        false, 33, std::span(nodes), std::span(types), std::span(ts), sample_count, std::span(output_neighbor_ids),
-        std::span(output_neighbor_types), std::span(output_neighbors_total_counts), std::span(output_edge_created_ts),
-        42, 13);
+        false, true, 33, std::span(nodes), std::span(types), std::span(ts), sample_count,
+        std::span(output_neighbor_ids), std::span(output_neighbor_types), std::span(output_neighbors_total_counts),
+        std::span(output_edge_created_ts), 42, 13);
 
     // Only available neighbors based on time/type are 5 and 7
     EXPECT_EQ(std::vector<snark::NodeId>({42, 42, 7, 5}), output_neighbor_ids);
@@ -528,7 +528,7 @@ TEST_F(TemporalTest, GetUniformSampleNeighborMultiplePartitions)
     std::fill(std::begin(output_edge_created_ts), std::end(output_edge_created_ts), -2);
 
     m_multi_partition_graph->UniformSampleNeighbor(
-        true, 33, std::span(nodes), std::span(types), std::span(ts), sample_count, std::span(output_neighbor_ids),
+        true, true, 33, std::span(nodes), std::span(types), std::span(ts), sample_count, std::span(output_neighbor_ids),
         std::span(output_neighbor_types), std::span(output_neighbors_total_counts), std::span(output_edge_created_ts),
         42, 13);
 
@@ -544,9 +544,9 @@ TEST_F(TemporalTest, GetUniformSampleNeighborMultiplePartitions)
 
     ts = {1, 1};
     m_multi_partition_graph->UniformSampleNeighbor(
-        false, 33, std::span(nodes), std::span(types), std::span(ts), sample_count, std::span(output_neighbor_ids),
-        std::span(output_neighbor_types), std::span(output_neighbors_total_counts), std::span(output_edge_created_ts),
-        42, 13);
+        false, true, 33, std::span(nodes), std::span(types), std::span(ts), sample_count,
+        std::span(output_neighbor_ids), std::span(output_neighbor_types), std::span(output_neighbors_total_counts),
+        std::span(output_edge_created_ts), 42, 13);
     // Only available neighbors based on time/type is 5
     EXPECT_EQ(std::vector<snark::NodeId>({42, 42, 5, 5}), output_neighbor_ids);
     std::fill(std::begin(output_neighbor_ids), std::end(output_neighbor_ids), -1);
@@ -559,7 +559,7 @@ TEST_F(TemporalTest, GetUniformSampleNeighborMultiplePartitions)
     std::fill(std::begin(output_edge_created_ts), std::end(output_edge_created_ts), -2);
 
     m_multi_partition_graph->UniformSampleNeighbor(
-        true, 33, std::span(nodes), std::span(types), std::span(ts), sample_count, std::span(output_neighbor_ids),
+        true, true, 33, std::span(nodes), std::span(types), std::span(ts), sample_count, std::span(output_neighbor_ids),
         std::span(output_neighbor_types), std::span(output_neighbors_total_counts), std::span(output_edge_created_ts),
         42, 13);
 
@@ -578,9 +578,9 @@ TEST_F(TemporalTest, GetUniformSampleNeighborMultiplePartitions)
     types = {0, 1};
     ts = {0, 0};
     m_multi_partition_graph->UniformSampleNeighbor(
-        false, 36, std::span(nodes), std::span(types), std::span(ts), sample_count, std::span(output_neighbor_ids),
-        std::span(output_neighbor_types), std::span(output_neighbors_total_counts), std::span(output_edge_created_ts),
-        42, 13);
+        false, true, 36, std::span(nodes), std::span(types), std::span(ts), sample_count,
+        std::span(output_neighbor_ids), std::span(output_neighbor_types), std::span(output_neighbors_total_counts),
+        std::span(output_edge_created_ts), 42, 13);
     EXPECT_EQ(std::vector<snark::NodeId>({1, 2, 6, 3}), output_neighbor_ids);
     EXPECT_EQ(std::vector<snark::Type>({0, 0, 1, 0}), output_neighbor_types);
     EXPECT_EQ(std::vector<uint64_t>({2, 2}), output_neighbors_total_counts);
@@ -599,7 +599,7 @@ TEST_F(TemporalTest, GetFullNeighborDistributed)
     std::vector<snark::Type> output_neighbor_types;
     std::vector<float> output_neighbors_weights;
     std::vector<snark::Timestamp> output_edge_created_ts;
-    m_distributed_graph->FullNeighbor(std::span(nodes), std::span(types), std::span(ts), output_neighbor_ids,
+    m_distributed_graph->FullNeighbor(true, std::span(nodes), std::span(types), std::span(ts), output_neighbor_ids,
                                       output_neighbor_types, output_neighbors_weights, output_edge_created_ts,
                                       std::span(output_neighbors_count));
     EXPECT_EQ(std::vector<snark::NodeId>({5, 7}), output_neighbor_ids);
@@ -637,10 +637,10 @@ TEST_F(TemporalTest, GetSampleNeighborsDistributed)
     std::vector<snark::Type> output_neighbor_types(sample_count * nodes.size());
     std::vector<float> output_neighbors_weights(sample_count * nodes.size());
     std::vector<snark::Timestamp> output_edge_created_ts(sample_count * nodes.size(), -2);
-    m_distributed_graph->WeightedSampleNeighbor(37, std::span(nodes), std::span(types), std::span(ts), sample_count,
-                                                std::span(output_neighbor_ids), std::span(output_neighbor_types),
-                                                std::span(output_neighbors_weights), std::span(output_edge_created_ts),
-                                                42, 0.5f, 13);
+    m_distributed_graph->WeightedSampleNeighbor(true, 37, std::span(nodes), std::span(types), std::span(ts),
+                                                sample_count, std::span(output_neighbor_ids),
+                                                std::span(output_neighbor_types), std::span(output_neighbors_weights),
+                                                std::span(output_edge_created_ts), 42, 0.5f, 13);
     EXPECT_EQ(std::vector<snark::NodeId>({42, 42, 4, 4}), output_neighbor_ids);
     EXPECT_EQ(std::vector<snark::Type>({13, 13, 0, 0}), output_neighbor_types);
     EXPECT_EQ(std::vector<float>({0.5f, 0.5f, 1.f, 1.f}), output_neighbors_weights);
@@ -660,7 +660,7 @@ TEST_F(TemporalTest, GetUniformSampleNeighborsDistributed)
     std::vector<snark::Type> output_neighbor_types(sample_count * nodes.size());
     std::vector<snark::Timestamp> output_edge_created_ts(sample_count * nodes.size(), -2);
     m_distributed_graph->UniformSampleNeighbor(
-        true, 37, std::span(nodes), std::span(types), std::span(ts), sample_count, std::span(output_neighbor_ids),
+        true, true, 37, std::span(nodes), std::span(types), std::span(ts), sample_count, std::span(output_neighbor_ids),
         std::span(output_neighbor_types), std::span(output_edge_created_ts), 42, 13);
     EXPECT_EQ(std::vector<snark::NodeId>({42, 42, 4, 42}), output_neighbor_ids);
     EXPECT_EQ(std::vector<snark::Type>({13, 13, 0, 13}), output_neighbor_types);
@@ -672,8 +672,8 @@ TEST_F(TemporalTest, GetUniformSampleNeighborsDistributed)
     std::fill(std::begin(output_neighbor_types), std::end(output_neighbor_types), -2);
     std::fill(std::begin(output_edge_created_ts), std::end(output_edge_created_ts), -2);
     m_distributed_graph->UniformSampleNeighbor(
-        false, 37, std::span(nodes), std::span(types), std::span(ts), sample_count, std::span(output_neighbor_ids),
-        std::span(output_neighbor_types), std::span(output_edge_created_ts), 42, 13);
+        false, true, 37, std::span(nodes), std::span(types), std::span(ts), sample_count,
+        std::span(output_neighbor_ids), std::span(output_neighbor_types), std::span(output_edge_created_ts), 42, 13);
     EXPECT_EQ(std::vector<snark::NodeId>({42, 42, 4, 4}), output_neighbor_ids);
     EXPECT_EQ(std::vector<snark::Type>({13, 13, 0, 0}), output_neighbor_types);
     EXPECT_EQ(std::vector<snark::Timestamp>({snark::PLACEHOLDER_TIMESTAMP, snark::PLACEHOLDER_TIMESTAMP, 1, 1}),
@@ -693,9 +693,9 @@ template <typename Graph> void GetLastNCreatedNeighbors(Graph &g)
     std::vector<snark::Type> output_neighbor_types(sample_count * nodes.size());
     std::vector<float> output_neighbors_weights(sample_count * nodes.size());
     std::vector<snark::Timestamp> output_timestamps(sample_count * nodes.size());
-    g->LastNCreated(std::span(nodes), std::span(types), std::span(ts), sample_count, std::span(output_neighbor_ids),
-                    std::span(output_neighbor_types), std::span(output_neighbors_weights), std::span(output_timestamps),
-                    42, 0.5f, 13, 99);
+    g->LastNCreated(true, std::span(nodes), std::span(types), std::span(ts), sample_count,
+                    std::span(output_neighbor_ids), std::span(output_neighbor_types),
+                    std::span(output_neighbors_weights), std::span(output_timestamps), 42, 0.5f, 13, 99);
     EXPECT_EQ(std::vector<snark::NodeId>({42, 42, 4, 42}), output_neighbor_ids);
     EXPECT_EQ(std::vector<snark::Type>({13, 13, 0, 13}), output_neighbor_types);
     EXPECT_EQ(std::vector<float>({0.5f, 0.5f, 1.f, 0.5f}), output_neighbors_weights);

--- a/src/cc/tests/temporal_test.cc
+++ b/src/cc/tests/temporal_test.cc
@@ -191,17 +191,19 @@ TEST_F(TemporalTest, GetFullNeighborSinglePartition)
     std::vector<snark::NodeId> output_neighbor_ids;
     std::vector<snark::Type> output_neighbor_types;
     std::vector<float> output_neighbors_weights;
+    std::vector<snark::Timestamp> output_edge_created_ts;
     m_single_partition_graph->FullNeighbor(std::span(nodes), std::span(types), std::span(ts), output_neighbor_ids,
-                                           output_neighbor_types, output_neighbors_weights,
+                                           output_neighbor_types, output_neighbors_weights, output_edge_created_ts,
                                            std::span(output_neighbors_count));
     EXPECT_TRUE(output_neighbor_ids.empty());
     EXPECT_TRUE(output_neighbor_types.empty());
     EXPECT_TRUE(output_neighbors_weights.empty());
+    EXPECT_TRUE(output_edge_created_ts.empty());
     EXPECT_EQ(std::vector<uint64_t>({0, 0}), output_neighbors_count);
 
     ts = {0, 0};
     m_single_partition_graph->FullNeighbor(std::span(nodes), std::span(types), std::span(ts), output_neighbor_ids,
-                                           output_neighbor_types, output_neighbors_weights,
+                                           output_neighbor_types, output_neighbors_weights, output_edge_created_ts,
                                            std::span(output_neighbors_count));
     EXPECT_EQ(std::vector<snark::NodeId>({1, 2, 3}), output_neighbor_ids);
     output_neighbor_ids.clear();
@@ -209,6 +211,8 @@ TEST_F(TemporalTest, GetFullNeighborSinglePartition)
     output_neighbor_types.clear();
     EXPECT_EQ(std::vector<float>({1.f, 2.f, 1.f}), output_neighbors_weights);
     output_neighbors_weights.clear();
+    EXPECT_EQ(std::vector<snark::Timestamp>({0, 0, 0}), output_edge_created_ts);
+    output_edge_created_ts.clear();
     EXPECT_EQ(std::vector<uint64_t>({2, 1}), output_neighbors_count);
     std::fill_n(output_neighbors_count.begin(), 2, -1);
 
@@ -216,7 +220,7 @@ TEST_F(TemporalTest, GetFullNeighborSinglePartition)
     types = {1};
     ts = {2, 2};
     m_single_partition_graph->FullNeighbor(std::span(nodes), std::span(types), std::span(ts), output_neighbor_ids,
-                                           output_neighbor_types, output_neighbors_weights,
+                                           output_neighbor_types, output_neighbors_weights, output_edge_created_ts,
                                            std::span(output_neighbors_count));
     EXPECT_EQ(std::vector<snark::NodeId>({5}), output_neighbor_ids);
     output_neighbor_ids.clear();
@@ -224,13 +228,15 @@ TEST_F(TemporalTest, GetFullNeighborSinglePartition)
     output_neighbor_types.clear();
     EXPECT_EQ(std::vector<float>({7.f}), output_neighbors_weights);
     output_neighbors_weights.clear();
+    EXPECT_EQ(std::vector<snark::Timestamp>({2}), output_edge_created_ts);
+    output_edge_created_ts.clear();
     EXPECT_EQ(std::vector<uint64_t>({0, 1}), output_neighbors_count);
     std::fill_n(output_neighbors_count.begin(), 2, -1);
 
     // Check for both edge types
     types = {0, 1};
     m_single_partition_graph->FullNeighbor(std::span(nodes), std::span(types), std::span(ts), output_neighbor_ids,
-                                           output_neighbor_types, output_neighbors_weights,
+                                           output_neighbor_types, output_neighbors_weights, output_edge_created_ts,
                                            std::span(output_neighbors_count));
     EXPECT_EQ(std::vector<snark::NodeId>({5}), output_neighbor_ids);
     output_neighbor_ids.clear();
@@ -238,6 +244,8 @@ TEST_F(TemporalTest, GetFullNeighborSinglePartition)
     output_neighbor_types.clear();
     EXPECT_EQ(std::vector<float>({7.f}), output_neighbors_weights);
     output_neighbors_weights.clear();
+    EXPECT_EQ(std::vector<snark::Timestamp>({2}), output_edge_created_ts);
+    output_edge_created_ts.clear();
     EXPECT_EQ(std::vector<uint64_t>({0, 1}), output_neighbors_count);
     std::fill_n(output_neighbors_count.begin(), 2, -1);
 
@@ -246,11 +254,12 @@ TEST_F(TemporalTest, GetFullNeighborSinglePartition)
     std::fill_n(output_neighbors_count.begin(), 2, -1);
 
     m_single_partition_graph->FullNeighbor(std::span(nodes), std::span(types), std::span(ts), output_neighbor_ids,
-                                           output_neighbor_types, output_neighbors_weights,
+                                           output_neighbor_types, output_neighbors_weights, output_edge_created_ts,
                                            std::span(output_neighbors_count));
     EXPECT_TRUE(output_neighbor_ids.empty());
     EXPECT_TRUE(output_neighbor_types.empty());
     EXPECT_TRUE(output_neighbors_weights.empty());
+    EXPECT_TRUE(output_edge_created_ts.empty());
     EXPECT_EQ(std::vector<uint64_t>({0, 0}), output_neighbors_count);
 
     // Invalid node ids
@@ -259,11 +268,12 @@ TEST_F(TemporalTest, GetFullNeighborSinglePartition)
     std::fill_n(output_neighbors_count.begin(), 2, -1);
 
     m_single_partition_graph->FullNeighbor(std::span(nodes), std::span(types), std::span(ts), output_neighbor_ids,
-                                           output_neighbor_types, output_neighbors_weights,
+                                           output_neighbor_types, output_neighbors_weights, output_edge_created_ts,
                                            std::span(output_neighbors_count));
     EXPECT_TRUE(output_neighbor_ids.empty());
     EXPECT_TRUE(output_neighbor_types.empty());
     EXPECT_TRUE(output_neighbors_weights.empty());
+    EXPECT_TRUE(output_edge_created_ts.empty());
     EXPECT_EQ(std::vector<uint64_t>({0, 0}), output_neighbors_count);
 }
 
@@ -312,8 +322,9 @@ TEST_F(TemporalTest, GetFullNeighborMultiplePartitions)
     std::vector<snark::NodeId> output_neighbor_ids;
     std::vector<snark::Type> output_neighbor_types;
     std::vector<float> output_neighbors_weights;
+    std::vector<snark::Timestamp> output_edge_created_ts;
     m_multi_partition_graph->FullNeighbor(std::span(nodes), std::span(types), std::span(ts), output_neighbor_ids,
-                                          output_neighbor_types, output_neighbors_weights,
+                                          output_neighbor_types, output_neighbors_weights, output_edge_created_ts,
                                           std::span(output_neighbors_count));
     EXPECT_EQ(std::vector<snark::NodeId>({5, 7}), output_neighbor_ids);
     output_neighbor_ids.clear();
@@ -321,13 +332,15 @@ TEST_F(TemporalTest, GetFullNeighborMultiplePartitions)
     output_neighbor_types.clear();
     EXPECT_EQ(std::vector<float>({1.f, 3.0f}), output_neighbors_weights);
     output_neighbors_weights.clear();
+    EXPECT_EQ(std::vector<snark::Timestamp>({1, 2}), output_edge_created_ts);
+    output_edge_created_ts.clear();
     EXPECT_EQ(std::vector<uint64_t>({0, 2}), output_neighbors_count);
     std::fill_n(output_neighbors_count.begin(), 2, -1);
 
     // Check for multiple edge types
     types = {0, 1};
     m_multi_partition_graph->FullNeighbor(std::span(nodes), std::span(types), std::span(ts), output_neighbor_ids,
-                                          output_neighbor_types, output_neighbors_weights,
+                                          output_neighbor_types, output_neighbors_weights, output_edge_created_ts,
                                           std::span(output_neighbors_count));
     EXPECT_EQ(std::vector<snark::NodeId>({4, 5, 7}), output_neighbor_ids);
     output_neighbor_ids.clear();
@@ -335,6 +348,8 @@ TEST_F(TemporalTest, GetFullNeighborMultiplePartitions)
     output_neighbor_types.clear();
     EXPECT_EQ(std::vector<float>({1.f, 1.f, 3.f}), output_neighbors_weights);
     output_neighbors_weights.clear();
+    EXPECT_EQ(std::vector<snark::Timestamp>({1, 1, 2}), output_edge_created_ts);
+    output_edge_created_ts.clear();
     EXPECT_EQ(std::vector<uint64_t>({0, 3}), output_neighbors_count);
     std::fill_n(output_neighbors_count.begin(), 2, -1);
 
@@ -342,7 +357,7 @@ TEST_F(TemporalTest, GetFullNeighborMultiplePartitions)
     types = {0};
     ts = {2, 2};
     m_multi_partition_graph->FullNeighbor(std::span(nodes), std::span(types), std::span(ts), output_neighbor_ids,
-                                          output_neighbor_types, output_neighbors_weights,
+                                          output_neighbor_types, output_neighbors_weights, output_edge_created_ts,
                                           std::span(output_neighbors_count));
     EXPECT_EQ(std::vector<snark::NodeId>({4}), output_neighbor_ids);
     output_neighbor_ids.clear();
@@ -350,6 +365,8 @@ TEST_F(TemporalTest, GetFullNeighborMultiplePartitions)
     output_neighbor_types.clear();
     EXPECT_EQ(std::vector<float>({1.f}), output_neighbors_weights);
     output_neighbors_weights.clear();
+    EXPECT_EQ(std::vector<snark::Timestamp>({1}), output_edge_created_ts);
+    output_edge_created_ts.clear();
     EXPECT_EQ(std::vector<uint64_t>({0, 1}), output_neighbors_count);
     std::fill_n(output_neighbors_count.begin(), 2, -1);
 
@@ -358,11 +375,12 @@ TEST_F(TemporalTest, GetFullNeighborMultiplePartitions)
     std::fill_n(output_neighbors_count.begin(), 2, -1);
 
     m_multi_partition_graph->FullNeighbor(std::span(nodes), std::span(types), std::span(ts), output_neighbor_ids,
-                                          output_neighbor_types, output_neighbors_weights,
+                                          output_neighbor_types, output_neighbors_weights, output_edge_created_ts,
                                           std::span(output_neighbors_count));
     EXPECT_TRUE(output_neighbor_ids.empty());
     EXPECT_TRUE(output_neighbor_types.empty());
     EXPECT_TRUE(output_neighbors_weights.empty());
+    EXPECT_TRUE(output_edge_created_ts.empty());
     EXPECT_EQ(std::vector<uint64_t>({0, 0}), output_neighbors_count);
 
     // Invalid node ids
@@ -371,11 +389,12 @@ TEST_F(TemporalTest, GetFullNeighborMultiplePartitions)
     std::fill_n(output_neighbors_count.begin(), 2, -1);
 
     m_multi_partition_graph->FullNeighbor(std::span(nodes), std::span(types), std::span(ts), output_neighbor_ids,
-                                          output_neighbor_types, output_neighbors_weights,
+                                          output_neighbor_types, output_neighbors_weights, output_edge_created_ts,
                                           std::span(output_neighbors_count));
     EXPECT_TRUE(output_neighbor_ids.empty());
     EXPECT_TRUE(output_neighbor_types.empty());
     EXPECT_TRUE(output_neighbors_weights.empty());
+    EXPECT_TRUE(output_edge_created_ts.empty());
     EXPECT_EQ(std::vector<uint64_t>({0, 0}), output_neighbors_count);
 }
 
@@ -391,10 +410,11 @@ TEST_F(TemporalTest, GetSampleNeighborsMultiplePartitions)
     std::vector<snark::Type> output_neighbor_types(sample_count * nodes.size());
     std::vector<float> output_neighbors_weights(sample_count * nodes.size());
     std::vector<float> output_neighbors_total_weights(nodes.size());
-    m_multi_partition_graph->SampleNeighbor(33, std::span(nodes), std::span(types), std::span(ts), sample_count,
-                                            std::span(output_neighbor_ids), std::span(output_neighbor_types),
-                                            std::span(output_neighbors_weights),
-                                            std::span(output_neighbors_total_weights), 42, 0.5f, 13);
+    std::vector<snark::Timestamp> output_edge_created_ts(sample_count * nodes.size(), -2);
+    m_multi_partition_graph->SampleNeighbor(
+        33, std::span(nodes), std::span(types), std::span(ts), sample_count, std::span(output_neighbor_ids),
+        std::span(output_neighbor_types), std::span(output_neighbors_weights),
+        std::span(output_neighbors_total_weights), std::span(output_edge_created_ts), 42, 0.5f, 13);
 
     // Only available neighbor based on time/type is 5
     EXPECT_EQ(std::vector<snark::NodeId>({42, 42, 5, 5}), output_neighbor_ids);
@@ -405,13 +425,16 @@ TEST_F(TemporalTest, GetSampleNeighborsMultiplePartitions)
     std::fill(std::begin(output_neighbors_weights), std::end(output_neighbors_weights), -1);
     EXPECT_EQ(std::vector<float>({0.f, 4.0f}), output_neighbors_total_weights);
     std::fill(std::begin(output_neighbors_total_weights), std::end(output_neighbors_total_weights), 0);
+    EXPECT_EQ(std::vector<snark::Timestamp>({snark::PLACEHOLDER_TIMESTAMP, snark::PLACEHOLDER_TIMESTAMP, 1, 1}),
+              output_edge_created_ts);
+    std::fill(std::begin(output_edge_created_ts), std::end(output_edge_created_ts), -2);
 
     // Check for multiple edge types
     types = {0, 1};
-    m_multi_partition_graph->SampleNeighbor(36, std::span(nodes), std::span(types), std::span(ts), sample_count,
-                                            std::span(output_neighbor_ids), std::span(output_neighbor_types),
-                                            std::span(output_neighbors_weights),
-                                            std::span(output_neighbors_total_weights), 42, 0.5f, 13);
+    m_multi_partition_graph->SampleNeighbor(
+        36, std::span(nodes), std::span(types), std::span(ts), sample_count, std::span(output_neighbor_ids),
+        std::span(output_neighbor_types), std::span(output_neighbors_weights),
+        std::span(output_neighbors_total_weights), std::span(output_edge_created_ts), 42, 0.5f, 13);
     EXPECT_EQ(std::vector<snark::NodeId>({42, 42, 7, 5}), output_neighbor_ids);
     std::fill(std::begin(output_neighbor_ids), std::end(output_neighbor_ids), -1);
     EXPECT_EQ(std::vector<snark::Type>({13, 13, 1, 1}), output_neighbor_types);
@@ -420,14 +443,17 @@ TEST_F(TemporalTest, GetSampleNeighborsMultiplePartitions)
     std::fill(std::begin(output_neighbors_weights), std::end(output_neighbors_weights), -1);
     EXPECT_EQ(std::vector<float>({0.f, 5.f}), output_neighbors_total_weights);
     std::fill(std::begin(output_neighbors_total_weights), std::end(output_neighbors_total_weights), 0);
+    EXPECT_EQ(std::vector<snark::Timestamp>({snark::PLACEHOLDER_TIMESTAMP, snark::PLACEHOLDER_TIMESTAMP, 2, 1}),
+              output_edge_created_ts);
+    std::fill(std::begin(output_edge_created_ts), std::end(output_edge_created_ts), -2);
 
     // Check for different singe edge type filter
     types = {1};
     ts = {0, 0};
-    m_multi_partition_graph->SampleNeighbor(37, std::span(nodes), std::span(types), std::span(ts), sample_count,
-                                            std::span(output_neighbor_ids), std::span(output_neighbor_types),
-                                            std::span(output_neighbors_weights),
-                                            std::span(output_neighbors_total_weights), 42, 0.5f, 13);
+    m_multi_partition_graph->SampleNeighbor(
+        37, std::span(nodes), std::span(types), std::span(ts), sample_count, std::span(output_neighbor_ids),
+        std::span(output_neighbor_types), std::span(output_neighbors_weights),
+        std::span(output_neighbors_total_weights), std::span(output_edge_created_ts), 42, 0.5f, 13);
     EXPECT_EQ(std::vector<snark::NodeId>({42, 42, 6, 6}), output_neighbor_ids);
     std::fill(std::begin(output_neighbor_ids), std::end(output_neighbor_ids), -1);
     EXPECT_EQ(std::vector<snark::Type>({13, 13, 1, 1}), output_neighbor_types);
@@ -436,14 +462,17 @@ TEST_F(TemporalTest, GetSampleNeighborsMultiplePartitions)
     std::fill(std::begin(output_neighbors_weights), std::end(output_neighbors_weights), -1);
     EXPECT_EQ(std::vector<float>({0.f, 1.5f}), output_neighbors_total_weights);
     std::fill(std::begin(output_neighbors_total_weights), std::end(output_neighbors_total_weights), 0);
+    EXPECT_EQ(std::vector<snark::Timestamp>({snark::PLACEHOLDER_TIMESTAMP, snark::PLACEHOLDER_TIMESTAMP, 0, 0}),
+              output_edge_created_ts);
+    std::fill(std::begin(output_edge_created_ts), std::end(output_edge_created_ts), -2);
 
     // Check returns 0 for unsatisfying edge types
     types = {-1, 100};
 
-    m_multi_partition_graph->SampleNeighbor(33, std::span(nodes), std::span(types), std::span(ts), sample_count,
-                                            std::span(output_neighbor_ids), std::span(output_neighbor_types),
-                                            std::span(output_neighbors_weights),
-                                            std::span(output_neighbors_total_weights), 42, 0.5f, 13);
+    m_multi_partition_graph->SampleNeighbor(
+        33, std::span(nodes), std::span(types), std::span(ts), sample_count, std::span(output_neighbor_ids),
+        std::span(output_neighbor_types), std::span(output_neighbors_weights),
+        std::span(output_neighbors_total_weights), std::span(output_edge_created_ts), 42, 0.5f, 13);
     EXPECT_EQ(std::vector<snark::NodeId>({42, 42, 42, 42}), output_neighbor_ids);
     std::fill(std::begin(output_neighbor_ids), std::end(output_neighbor_ids), -1);
     EXPECT_EQ(std::vector<snark::Type>({13, 13, 13, 13}), output_neighbor_types);
@@ -452,20 +481,110 @@ TEST_F(TemporalTest, GetSampleNeighborsMultiplePartitions)
     std::fill(std::begin(output_neighbors_weights), std::end(output_neighbors_weights), -1);
     EXPECT_EQ(std::vector<float>({0.f, 0.f}), output_neighbors_total_weights);
     std::fill(std::begin(output_neighbors_total_weights), std::end(output_neighbors_total_weights), 0);
+    EXPECT_EQ(std::vector<snark::Timestamp>(4, snark::PLACEHOLDER_TIMESTAMP), output_edge_created_ts);
+    std::fill(std::begin(output_edge_created_ts), std::end(output_edge_created_ts), -2);
 
     // Invalid node ids
     nodes = {99, 100};
     types = {0, 1};
 
-    m_multi_partition_graph->SampleNeighbor(33, std::span(nodes), std::span(types), std::span(ts), sample_count,
-                                            std::span(output_neighbor_ids), std::span(output_neighbor_types),
-                                            std::span(output_neighbors_weights),
-                                            std::span(output_neighbors_total_weights), 42, 0.5f, 13);
+    m_multi_partition_graph->SampleNeighbor(
+        33, std::span(nodes), std::span(types), std::span(ts), sample_count, std::span(output_neighbor_ids),
+        std::span(output_neighbor_types), std::span(output_neighbors_weights),
+        std::span(output_neighbors_total_weights), std::span(output_edge_created_ts), 42, 0.5f, 13);
 
     EXPECT_EQ(std::vector<snark::NodeId>({42, 42, 42, 42}), output_neighbor_ids);
     EXPECT_EQ(std::vector<snark::Type>({13, 13, 13, 13}), output_neighbor_types);
     EXPECT_EQ(std::vector<float>({0.5f, 0.5f, 0.5f, 0.5f}), output_neighbors_weights);
     EXPECT_EQ(std::vector<float>({0.f, 0.f}), output_neighbors_total_weights);
+    EXPECT_EQ(std::vector<snark::Timestamp>(4, snark::PLACEHOLDER_TIMESTAMP), output_edge_created_ts);
+}
+
+TEST_F(TemporalTest, GetUniformSampleNeighborMultiplePartitions)
+{
+    // Check for singe edge type filter
+    std::vector<snark::NodeId> nodes = {0, 1};
+    std::vector<snark::Type> types = {1};
+    std::vector<snark::Timestamp> ts = {2, 2};
+    size_t sample_count = 2;
+
+    std::vector<snark::NodeId> output_neighbor_ids(sample_count * nodes.size());
+    std::vector<snark::Type> output_neighbor_types(sample_count * nodes.size());
+    std::vector<uint64_t> output_neighbors_total_counts(nodes.size());
+    std::vector<snark::Timestamp> output_edge_created_ts(sample_count * nodes.size(), -2);
+    m_multi_partition_graph->UniformSampleNeighbor(
+        false, 33, std::span(nodes), std::span(types), std::span(ts), sample_count, std::span(output_neighbor_ids),
+        std::span(output_neighbor_types), std::span(output_neighbors_total_counts), std::span(output_edge_created_ts),
+        42, 13);
+
+    // Only available neighbors based on time/type are 5 and 7
+    EXPECT_EQ(std::vector<snark::NodeId>({42, 42, 7, 5}), output_neighbor_ids);
+    std::fill(std::begin(output_neighbor_ids), std::end(output_neighbor_ids), -1);
+    EXPECT_EQ(std::vector<snark::Type>({13, 13, 1, 1}), output_neighbor_types);
+    std::fill(std::begin(output_neighbor_types), std::end(output_neighbor_types), -1);
+    std::fill(std::begin(output_neighbors_total_counts), std::end(output_neighbors_total_counts), 0);
+    EXPECT_EQ(std::vector<snark::Timestamp>({snark::PLACEHOLDER_TIMESTAMP, snark::PLACEHOLDER_TIMESTAMP, 2, 1}),
+              output_edge_created_ts);
+    std::fill(std::begin(output_edge_created_ts), std::end(output_edge_created_ts), -2);
+
+    m_multi_partition_graph->UniformSampleNeighbor(
+        true, 33, std::span(nodes), std::span(types), std::span(ts), sample_count, std::span(output_neighbor_ids),
+        std::span(output_neighbor_types), std::span(output_neighbors_total_counts), std::span(output_edge_created_ts),
+        42, 13);
+
+    EXPECT_EQ(std::vector<snark::NodeId>({42, 42, 5, 7}), output_neighbor_ids);
+    std::fill(std::begin(output_neighbor_ids), std::end(output_neighbor_ids), -1);
+    EXPECT_EQ(std::vector<snark::Type>({13, 13, 1, 1}), output_neighbor_types);
+    std::fill(std::begin(output_neighbor_types), std::end(output_neighbor_types), -1);
+    EXPECT_EQ(std::vector<uint64_t>({0, 2}), output_neighbors_total_counts);
+    std::fill(std::begin(output_neighbors_total_counts), std::end(output_neighbors_total_counts), 0);
+    EXPECT_EQ(std::vector<snark::Timestamp>({snark::PLACEHOLDER_TIMESTAMP, snark::PLACEHOLDER_TIMESTAMP, 1, 2}),
+              output_edge_created_ts);
+    std::fill(std::begin(output_edge_created_ts), std::end(output_edge_created_ts), -2);
+
+    ts = {1, 1};
+    m_multi_partition_graph->UniformSampleNeighbor(
+        false, 33, std::span(nodes), std::span(types), std::span(ts), sample_count, std::span(output_neighbor_ids),
+        std::span(output_neighbor_types), std::span(output_neighbors_total_counts), std::span(output_edge_created_ts),
+        42, 13);
+    // Only available neighbors based on time/type is 5
+    EXPECT_EQ(std::vector<snark::NodeId>({42, 42, 5, 5}), output_neighbor_ids);
+    std::fill(std::begin(output_neighbor_ids), std::end(output_neighbor_ids), -1);
+    EXPECT_EQ(std::vector<snark::Type>({13, 13, 1, 1}), output_neighbor_types);
+    std::fill(std::begin(output_neighbor_types), std::end(output_neighbor_types), -1);
+    EXPECT_EQ(std::vector<uint64_t>({0, 1}), output_neighbors_total_counts);
+    std::fill(std::begin(output_neighbors_total_counts), std::end(output_neighbors_total_counts), 0);
+    EXPECT_EQ(std::vector<snark::Timestamp>({snark::PLACEHOLDER_TIMESTAMP, snark::PLACEHOLDER_TIMESTAMP, 1, 1}),
+              output_edge_created_ts);
+    std::fill(std::begin(output_edge_created_ts), std::end(output_edge_created_ts), -2);
+
+    m_multi_partition_graph->UniformSampleNeighbor(
+        true, 33, std::span(nodes), std::span(types), std::span(ts), sample_count, std::span(output_neighbor_ids),
+        std::span(output_neighbor_types), std::span(output_neighbors_total_counts), std::span(output_edge_created_ts),
+        42, 13);
+
+    EXPECT_EQ(std::vector<snark::NodeId>({42, 42, 5, 42}), output_neighbor_ids);
+    std::fill(std::begin(output_neighbor_ids), std::end(output_neighbor_ids), -1);
+    EXPECT_EQ(std::vector<snark::Type>({13, 13, 1, 13}), output_neighbor_types);
+    std::fill(std::begin(output_neighbor_types), std::end(output_neighbor_types), -1);
+    EXPECT_EQ(std::vector<uint64_t>({0, 1}), output_neighbors_total_counts);
+    std::fill(std::begin(output_neighbors_total_counts), std::end(output_neighbors_total_counts), 0);
+    EXPECT_EQ(std::vector<snark::Timestamp>(
+                  {snark::PLACEHOLDER_TIMESTAMP, snark::PLACEHOLDER_TIMESTAMP, 1, snark::PLACEHOLDER_TIMESTAMP}),
+              output_edge_created_ts);
+    std::fill(std::begin(output_edge_created_ts), std::end(output_edge_created_ts), -2);
+
+    // Check for multiple edge types
+    types = {0, 1};
+    ts = {0, 0};
+    m_multi_partition_graph->UniformSampleNeighbor(
+        false, 36, std::span(nodes), std::span(types), std::span(ts), sample_count, std::span(output_neighbor_ids),
+        std::span(output_neighbor_types), std::span(output_neighbors_total_counts), std::span(output_edge_created_ts),
+        42, 13);
+    EXPECT_EQ(std::vector<snark::NodeId>({1, 2, 6, 3}), output_neighbor_ids);
+    EXPECT_EQ(std::vector<snark::Type>({0, 0, 1, 0}), output_neighbor_types);
+    EXPECT_EQ(std::vector<uint64_t>({2, 2}), output_neighbors_total_counts);
+    EXPECT_EQ(std::vector<snark::Timestamp>({0, 0, 0, 0}), output_edge_created_ts);
 }
 
 TEST_F(TemporalTest, GetFullNeighborDistributed)
@@ -479,13 +598,15 @@ TEST_F(TemporalTest, GetFullNeighborDistributed)
     std::vector<snark::NodeId> output_neighbor_ids;
     std::vector<snark::Type> output_neighbor_types;
     std::vector<float> output_neighbors_weights;
+    std::vector<snark::Timestamp> output_edge_created_ts;
     m_distributed_graph->FullNeighbor(std::span(nodes), std::span(types), std::span(ts), output_neighbor_ids,
-                                      output_neighbor_types, output_neighbors_weights,
+                                      output_neighbor_types, output_neighbors_weights, output_edge_created_ts,
                                       std::span(output_neighbors_count));
     EXPECT_EQ(std::vector<snark::NodeId>({5, 7}), output_neighbor_ids);
     EXPECT_EQ(std::vector<snark::Type>({1, 1}), output_neighbor_types);
     EXPECT_EQ(std::vector<float>({1.f, 3.0f}), output_neighbors_weights);
     EXPECT_EQ(std::vector<uint64_t>({0, 2}), output_neighbors_count);
+    EXPECT_EQ(std::vector<snark::Timestamp>({1, 2}), output_edge_created_ts);
 }
 
 TEST_F(TemporalTest, GetNeighborCountDistributed)
@@ -515,12 +636,48 @@ TEST_F(TemporalTest, GetSampleNeighborsDistributed)
     std::vector<snark::NodeId> output_neighbor_ids(sample_count * nodes.size());
     std::vector<snark::Type> output_neighbor_types(sample_count * nodes.size());
     std::vector<float> output_neighbors_weights(sample_count * nodes.size());
+    std::vector<snark::Timestamp> output_edge_created_ts(sample_count * nodes.size(), -2);
     m_distributed_graph->WeightedSampleNeighbor(37, std::span(nodes), std::span(types), std::span(ts), sample_count,
                                                 std::span(output_neighbor_ids), std::span(output_neighbor_types),
-                                                std::span(output_neighbors_weights), 42, 0.5f, 13);
+                                                std::span(output_neighbors_weights), std::span(output_edge_created_ts),
+                                                42, 0.5f, 13);
     EXPECT_EQ(std::vector<snark::NodeId>({42, 42, 4, 4}), output_neighbor_ids);
     EXPECT_EQ(std::vector<snark::Type>({13, 13, 0, 0}), output_neighbor_types);
     EXPECT_EQ(std::vector<float>({0.5f, 0.5f, 1.f, 1.f}), output_neighbors_weights);
+    EXPECT_EQ(std::vector<snark::Timestamp>({snark::PLACEHOLDER_TIMESTAMP, snark::PLACEHOLDER_TIMESTAMP, 1, 1}),
+              output_edge_created_ts);
+}
+
+TEST_F(TemporalTest, GetUniformSampleNeighborsDistributed)
+{
+    std::vector<snark::NodeId> nodes = {0, 1};
+    // Keep types = 0 to keep test stable and avoid merging neighbors from multiple shards.
+    std::vector<snark::Type> types = {0};
+    std::vector<snark::Timestamp> ts = {2, 2};
+    size_t sample_count = 2;
+
+    std::vector<snark::NodeId> output_neighbor_ids(sample_count * nodes.size());
+    std::vector<snark::Type> output_neighbor_types(sample_count * nodes.size());
+    std::vector<snark::Timestamp> output_edge_created_ts(sample_count * nodes.size(), -2);
+    m_distributed_graph->UniformSampleNeighbor(
+        true, 37, std::span(nodes), std::span(types), std::span(ts), sample_count, std::span(output_neighbor_ids),
+        std::span(output_neighbor_types), std::span(output_edge_created_ts), 42, 13);
+    EXPECT_EQ(std::vector<snark::NodeId>({42, 42, 4, 42}), output_neighbor_ids);
+    EXPECT_EQ(std::vector<snark::Type>({13, 13, 0, 13}), output_neighbor_types);
+    EXPECT_EQ(std::vector<snark::Timestamp>(
+                  {snark::PLACEHOLDER_TIMESTAMP, snark::PLACEHOLDER_TIMESTAMP, 1, snark::PLACEHOLDER_TIMESTAMP}),
+              output_edge_created_ts);
+
+    std::fill(std::begin(output_neighbor_ids), std::end(output_neighbor_ids), -2);
+    std::fill(std::begin(output_neighbor_types), std::end(output_neighbor_types), -2);
+    std::fill(std::begin(output_edge_created_ts), std::end(output_edge_created_ts), -2);
+    m_distributed_graph->UniformSampleNeighbor(
+        false, 37, std::span(nodes), std::span(types), std::span(ts), sample_count, std::span(output_neighbor_ids),
+        std::span(output_neighbor_types), std::span(output_edge_created_ts), 42, 13);
+    EXPECT_EQ(std::vector<snark::NodeId>({42, 42, 4, 4}), output_neighbor_ids);
+    EXPECT_EQ(std::vector<snark::Type>({13, 13, 0, 0}), output_neighbor_types);
+    EXPECT_EQ(std::vector<snark::Timestamp>({snark::PLACEHOLDER_TIMESTAMP, snark::PLACEHOLDER_TIMESTAMP, 1, 1}),
+              output_edge_created_ts);
 }
 
 namespace

--- a/src/python/deepgnn/graph_engine/_base.py
+++ b/src/python/deepgnn/graph_engine/_base.py
@@ -80,7 +80,11 @@ class Graph(abc.ABC):
         alpha: float = 0.5,
         eps: float = 0.0001,
         timestamps: Union[List[int], np.ndarray] = None,
-    ) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+        return_edge_created_ts: bool = False,
+    ) -> Union[
+        Tuple[np.ndarray, np.ndarray, np.ndarray],
+        Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray],
+    ]:
         """
         Sample node neighbors.
 
@@ -95,8 +99,9 @@ class Graph(abc.ABC):
         alpha -- ppr sampling teleport probability.
         eps -- stopping threshold for ppr sampling.
         timestamps -- timestamps to specify graph snapshot to sample neighbors for every node in a temporal graph.
+        return_edge_created_ts -- if specified, timestamps will be added to the end of returned tuple.
 
-        Returns a tuple of arrays nodes(np.uint64), weights(np.float), types(np.int32) and timestamps(np.int64)(for temporal graphs) with shape [len(nodes), count]
+        Returns a tuple of arrays nodes(np.uint64), weights(np.float), types(np.int32) and timestamps(np.int64)(if return_edge_created_ts is set) with shape [len(nodes), count]
         """
         raise NotImplementedError
 
@@ -131,7 +136,11 @@ class Graph(abc.ABC):
         nodes: np.ndarray,
         edge_types: Union[int, np.ndarray],
         timestamps: Optional[np.ndarray] = None,
-    ) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+        return_edge_created_ts: bool = False,
+    ) -> Union[
+        Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray],
+        Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray],
+    ]:
         """
         Full list of node neighbors.
 
@@ -140,12 +149,13 @@ class Graph(abc.ABC):
         timestamps -- timestamps to specify graph snapshot to retrieve neighbors for every node in a temporal graph.
 
         Returns a tuple of numpy arrays:
-        -- neighbor counts per node, with the shape [len(nodes)]
         -- neighbor ids per node, a one dimensional list of node ids
            concatenated in the same order as input nodes.
         -- weights for every neighbor, a one dimensional array
            of neighbor weights concatenated in the same order as input nodes.
         -- types of every neighbor.
+        -- number of neighbors for every input node.
+        -- timestamps of when edge connecting nodes was created (if return_edge_created_ts is set).
         """
         raise NotImplementedError
 

--- a/src/python/deepgnn/graph_engine/_base.py
+++ b/src/python/deepgnn/graph_engine/_base.py
@@ -96,7 +96,7 @@ class Graph(abc.ABC):
         eps -- stopping threshold for ppr sampling.
         timestamps -- timestamps to specify graph snapshot to sample neighbors for every node in a temporal graph.
 
-        Returns a tuple of arrays nodes(np.uint64), weights(np.float) and types(np.int) with shape [len(nodes), count]
+        Returns a tuple of arrays nodes(np.uint64), weights(np.float), types(np.int32) and timestamps(np.int64)(for temporal graphs) with shape [len(nodes), count]
         """
         raise NotImplementedError
 

--- a/src/python/deepgnn/graph_engine/graph_ops.py
+++ b/src/python/deepgnn/graph_engine/graph_ops.py
@@ -36,9 +36,8 @@ def sample_out_edges(
       * edges: out edges of `nodes`, `edges.shape == (len(nodes) * count, 3)`.
       * features: edge features. return `None` if `edge_feature_meta is None`
     """
-    nbrs, nbr_weights, nbr_types, nbr_cnt = graph.sample_neighbors(
-        nodes, edge_types, count, sampling_strategy
-    )
+    res = graph.sample_neighbors(nodes, edge_types, count, sampling_strategy)
+    nbrs, nbr_types = res[0], res[2]
     assert nbrs.shape == (len(nodes), count)
 
     # edges shape: (#edge, 3)
@@ -121,13 +120,14 @@ def sub_graph(
     """
     nodes = [src_nodes]
     for i in range(num_hops - 1):
-        nb, _, _, _ = graph.neighbors(nodes[i], edge_types)
+        nb = graph.neighbors(nodes[i], edge_types)[0]
         tmp = np.unique(nb)
         nodes.append(tmp)
 
     nodes = np.concatenate(nodes)
     unodes = np.unique(nodes)
-    nb, _, _, cnt = graph.neighbors(unodes, edge_types)
+    res = graph.neighbors(unodes, edge_types)
+    nb, cnt = res[0], res[3]
 
     # get all edges
     num_edges = np.sum(cnt)

--- a/src/python/deepgnn/graph_engine/snark/local.py
+++ b/src/python/deepgnn/graph_engine/snark/local.py
@@ -130,7 +130,7 @@ class Client(Graph):
                 result[0],
                 result[1],
                 result[2],
-                np.empty(result[0].shape, dtype=np.int64),
+                np.full(result[0].shape, -1, dtype=np.int64),
             )
         without_replacement = strategy == "randomwithoutreplacement"
         if strategy in ["random", "randomwithoutreplacement"]:
@@ -149,7 +149,9 @@ class Client(Graph):
                 result[0],
                 np.empty(result[0].shape, dtype=np.float32),
                 result[1],
-                result[2],
+                result[2]
+                if return_edge_created_ts
+                else np.full(result[0].shape, -1, dtype=np.int64),
             )
         if strategy == "ppr-go":
             result = self.graph.ppr_neighbors(  # type: ignore
@@ -166,7 +168,7 @@ class Client(Graph):
                 result[0],
                 result[1],
                 np.empty(0, dtype=np.int32),
-                np.empty(result[0].shape, dtype=np.int64),
+                np.full(result[0].shape, -1, dtype=np.int64),
             )
 
         if strategy == "lastn":

--- a/src/python/deepgnn/graph_engine/snark/local.py
+++ b/src/python/deepgnn/graph_engine/snark/local.py
@@ -119,7 +119,7 @@ class Client(Graph):
                 seed=int(random.getrandbits(64)),
                 timestamps=timestamps,
             )
-            return result[0], result[1], result[2], np.empty((1), dtype=np.int32)
+            return result[0], result[1], result[2], result[3]
         without_replacement = strategy == "randomwithoutreplacement"
         if strategy in ["random", "randomwithoutreplacement"]:
             result = self.graph.uniform_sample_neighbors(  # type: ignore
@@ -136,7 +136,7 @@ class Client(Graph):
                 result[0],
                 np.empty(result[0].shape, dtype=np.float32),
                 result[1],
-                np.empty((1), dtype=np.int32),
+                result[2],
             )
         if strategy == "ppr-go":
             result = self.graph.ppr_neighbors(  # type: ignore
@@ -153,7 +153,7 @@ class Client(Graph):
                 result[0],
                 result[1],
                 np.empty(0, dtype=np.int32),
-                np.empty(0, dtype=np.int32),
+                result[2],
             )
 
         if strategy == "lastn":

--- a/src/python/deepgnn/graph_engine/snark/tests/temporal_test.py
+++ b/src/python/deepgnn/graph_engine/snark/tests/temporal_test.py
@@ -156,7 +156,7 @@ def graph_dataset(multi_partition_graph_data, request):
 
 
 def test_neighbor_sampling_graph_multiple_partitions(graph_dataset):
-    ns, ws, ts = graph_dataset.weighted_sample_neighbors(
+    ns, ws, tp, ts = graph_dataset.weighted_sample_neighbors(
         nodes=np.array([0, 1], dtype=np.int64),
         edge_types=1,
         count=2,
@@ -167,7 +167,8 @@ def test_neighbor_sampling_graph_multiple_partitions(graph_dataset):
 
     npt.assert_array_equal(ns, [[5, 5], [13, 13]])
     npt.assert_array_equal(ws, [[1, 1], [-1, -1]])
-    npt.assert_array_equal(ts, [[1, 1], [-1, -1]])
+    npt.assert_array_equal(tp, [[1, 1], [-1, -1]])
+    npt.assert_array_equal(ts, [[-1, -1], [-1, -1]])
 
 
 def test_neighbor_count_graph_nonmatching_edge_type(graph_dataset):

--- a/src/python/deepgnn/graph_engine/snark/tests/temporal_test.py
+++ b/src/python/deepgnn/graph_engine/snark/tests/temporal_test.py
@@ -163,12 +163,28 @@ def test_neighbor_sampling_graph_multiple_partitions(graph_dataset):
         seed=3,
         default_node=13,
         default_weight=-1,
+        return_edge_created_ts=True,
     )
 
     npt.assert_array_equal(ns, [[5, 5], [13, 13]])
     npt.assert_array_equal(ws, [[1, 1], [-1, -1]])
     npt.assert_array_equal(tp, [[1, 1], [-1, -1]])
     npt.assert_array_equal(ts, [[-1, -1], [-1, -1]])
+
+
+def test_neighbor_sampling_graph_multiple_partitions(graph_dataset):
+    ns, ws, tp = graph_dataset.weighted_sample_neighbors(
+        nodes=np.array([0, 1], dtype=np.int64),
+        edge_types=1,
+        count=2,
+        seed=3,
+        default_node=13,
+        default_weight=-1,
+    )
+
+    npt.assert_array_equal(ns, [[5, 5], [13, 13]])
+    npt.assert_array_equal(ws, [[1, 1], [-1, -1]])
+    npt.assert_array_equal(tp, [[1, 1], [-1, -1]])
 
 
 def test_neighbor_count_graph_nonmatching_edge_type(graph_dataset):


### PR DESCRIPTION
- [x] Forked repo is synced with upstream -> github shows no code delta outside of the desired.
    https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork
- [x] Tests are passing? https://github.com/microsoft/DeepGNN/blob/main/CONTRIBUTING.md#run-tests
- [x] Changelog and documentation updated.
- [x] PR is labeled using the label menu on the right side.

Previous Behavior
----------------
We return 4 `np.arrays` in the `sample_neighborw` method from `_base.py`, but didn't fill the last element in that tuple.

New Behavior
----------------
1. Add timestamp information about the edge connecting 2 nodes, when it was created.
2. Implement uniform sampling for temporal graphs. I though it was added with temporal graphs, but somehow missed it.