### PR TITLE
Temporarily use windows-2019 image in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10"]
-        os: ["ubuntu-22.04", "macos-12", "windows-2022"]
+        os: ["ubuntu-22.04", "macos-12", "windows-2019"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3.3.0
@@ -29,7 +29,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.10"]
-        os: ["ubuntu-22.04", "macos-12", "windows-2022"]
+        os: ["ubuntu-22.04", "macos-12", "windows-2019"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3.3.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.10"]
-        os: ["ubuntu-22.04", "macos-12", "windows-2022"]
+        os: ["ubuntu-22.04", "macos-12", "windows-2019"]
     steps:
       - uses: actions/checkout@v3.3.0
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ["ubuntu-22.04", "macos-12", "windows-2022"]
+        os: ["ubuntu-22.04", "macos-12", "windows-2019"]
     steps:
       - uses: actions/checkout@v3.3.0
       - name: Set up Python 3.10


### PR DESCRIPTION
- [x] Forked repo is synced with upstream -> github shows no code delta outside of the desired.
    https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork
- [x] Tests are passing? https://github.com/microsoft/DeepGNN/blob/main/CONTRIBUTING.md#run-tests
- [x] Changelog and documentation updated.
- [x] PR is labeled using the label menu on the right side.

Previous Behavior
----------------
Builds started to fail for windows-2022 image and it is hard to pinpoint the issue form latest changes:
https://github.com/actions/runner-images/commit/bc7a4c29a673c70286eeeef66362bf2c55ed0093

New Behavior
----------------
Use windows-2019 image to unblock current pull requests.