### PR TITLE
Remove inputs for disk cache in bazel

### DIFF
--- a/.github/actions/benchmarks/action.yml
+++ b/.github/actions/benchmarks/action.yml
@@ -1,10 +1,5 @@
 name: "Benchmarks"
 description: "Run benchmarks"
-inputs:
-  disk_cache:
-    description: 'Build system cache key'
-    required: false
-    default: benchmark-${{ runner.os }}-${{ github.ref }}
 runs:
   using: "composite"
   steps:

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -1,10 +1,5 @@
 name: "Test"
 description: "Run unit tests"
-inputs:
-  disk_cache:
-    description: 'Build system cache key'
-    required: false
-    default: test-${{ github.ref }}-${{ runner.os }}
 runs:
   using: "composite"
   steps:
@@ -17,8 +12,6 @@ runs:
     - run: echo "BAZEL_CONFIG=macos" >> $GITHUB_ENV
       shell: bash
       if: runner.os == 'macOS'
-    - run: echo ${{ inputs.disk_cache }}
-      shell: bash
 
     - run: bazel test -c dbg //src/cc/tests:* --test_output=all --test_timeout 30 --config=${{ env.BAZEL_CONFIG }}
       shell: bash

--- a/.github/actions/wheel/action.yml
+++ b/.github/actions/wheel/action.yml
@@ -19,7 +19,7 @@ runs:
         sudo chown $USER /dt11
       shell: bash
       name: Configure env variables for linux
-    - uses: actions/cache@v3.2.3
+    - uses: actions/cache@v3.3.1
       id: compiler-cache
       with:
         path: /dt11

--- a/.github/actions/wheel/action.yml
+++ b/.github/actions/wheel/action.yml
@@ -5,10 +5,6 @@ inputs:
     description: 'Package version'
     required: true
     default: '0.1.1'
-  disk_cache:
-    description: 'Build system cache key'
-    required: false
-    default: wheel-${{ github.ref }}-${{ runner.os }}
 runs:
   using: "composite"
   steps:

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -7,6 +7,6 @@ jobs:
   linux:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3.3.0
+      - uses: actions/checkout@v3.5.3
       - name: Run benchmarks
         uses: ./.github/actions/benchmarks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,8 +39,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Run tests
         uses: ./.github/actions/test
-        with:
-          disk_cache: test-${{ matrix.os }}-${{ matrix.python-version }}
   benchmarks:
     needs: tests
     runs-on: "ubuntu-22.04"
@@ -48,8 +46,6 @@ jobs:
       - uses: actions/checkout@v3.3.0
       - name: Run benchmarks
         uses: ./.github/actions/benchmarks
-        with:
-          disk_cache: benchmark-${{ matrix.os }}
   wheel:
     runs-on: ubuntu-22.04
     needs: tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,12 +16,11 @@ jobs:
         os: ["ubuntu-22.04", "macos-12", "windows-2019"]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3.3.0
+      - uses: actions/checkout@v3.5.3
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4.5.0
+        uses: actions/setup-python@v4.7.0
         with:
           python-version: ${{ matrix.python-version }}
-          cache: 'pip'
       - name: Run lint
         uses: ./.github/actions/lint
   tests:
@@ -32,9 +31,9 @@ jobs:
         os: ["ubuntu-22.04", "macos-12", "windows-2019"]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3.3.0
+      - uses: actions/checkout@v3.5.3
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4.5.0
+        uses: actions/setup-python@v4.7.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Run tests
@@ -43,16 +42,16 @@ jobs:
     needs: tests
     runs-on: "ubuntu-22.04"
     steps:
-      - uses: actions/checkout@v3.3.0
+      - uses: actions/checkout@v3.5.3
       - name: Run benchmarks
         uses: ./.github/actions/benchmarks
   wheel:
     runs-on: ubuntu-22.04
     needs: tests
     steps:
-      - uses: actions/checkout@v3.3.0
+      - uses: actions/checkout@v3.5.3
       - name: Set up Python 3.10
-        uses: actions/setup-python@v4.5.0
+        uses: actions/setup-python@v4.7.0
         with:
           python-version: "3.10"
       - name: Upload examples
@@ -92,7 +91,7 @@ jobs:
         with:
           name: examples
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4.5.0
+        uses: actions/setup-python@v4.7.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install tensorflow
@@ -136,7 +135,7 @@ jobs:
         with:
           name: examples
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4.5.0
+        uses: actions/setup-python@v4.7.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install torch

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,11 +10,10 @@ jobs:
         os: ["ubuntu-22.04", "macos-12", "windows-2022"]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3.3.0
+      - uses: actions/checkout@v3.5.3
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4.5.0
+        uses: actions/setup-python@v4.7.0
         with:
           python-version: ${{ matrix.python-version }}
-          cache: 'pip'
       - name: Run lint
         uses: ./.github/actions/lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,9 +12,9 @@ jobs:
         python-version: ["3.10"]
         os: ["ubuntu-22.04", "macos-12", "windows-2019"]
     steps:
-      - uses: actions/checkout@v3.3.0
+      - uses: actions/checkout@v3.5.3
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4.5.0
+        uses: actions/setup-python@v4.7.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Run tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,5 +19,3 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Run tests
         uses: ./.github/actions/test
-        with:
-          disk_cache: test-${{ github.ref }}-${{ matrix.os }}-${{ matrix.python-version }}

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -15,9 +15,9 @@ jobs:
       matrix:
         os: ["ubuntu-22.04", "macos-12", "windows-2019"]
     steps:
-      - uses: actions/checkout@v3.3.0
+      - uses: actions/checkout@v3.5.3
       - name: Set up Python 3.10
-        uses: actions/setup-python@v4.5.0
+        uses: actions/setup-python@v4.7.0
         with:
           python-version: "3.10"
       - name: build wheel

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -24,7 +24,6 @@ jobs:
         uses: ./.github/actions/wheel
         with:
           package_version: ${{ github.event.inputs.package_version }}
-          disk_cache: wheel-${{ github.ref }}-${{ runner.os }}-${{ matrix.os }}-${{ matrix.python-version }}
       - name: Upload wheel file
         uses: actions/upload-artifact@v3.1.2
         with:


### PR DESCRIPTION
- [x] Forked repo is synced with upstream -> github shows no code delta outside of the desired.
    https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork
- [x] Tests are passing? https://github.com/microsoft/DeepGNN/blob/main/CONTRIBUTING.md#run-tests
- [x] PR is labeled using the label menu on the right side.

Previous Behavior
----------------
Inputs parameter is still passed to github actions, but it is never used. Pip cache uses 1.3 Gb per python version on linux:
![image](https://github.com/microsoft/DeepGNN/assets/134559/aaba6653-fb3f-4590-95c9-e2a6eeeb0fb3)


New Behavior
----------------
Removed: inputs variable and pip cache. Updated python actions versions.