### PR TITLE
Fix citation dataset on mac

### DIFF
--- a/src/python/deepgnn/graph_engine/data/citation.py
+++ b/src/python/deepgnn/graph_engine/data/citation.py
@@ -273,7 +273,7 @@ class CitationGraph(Client):
                     node_types[nid],
                     flt_feat=list(features[nid].tolist()),
                     label=int(labels[nid]),
-                    neighbors=adj[nid].nonzero()[1],
+                    neighbors=adj.getrow(nid).nonzero()[1],
                 )
                 fout.write(tmp)
 

--- a/src/python/setup.py
+++ b/src/python/setup.py
@@ -83,7 +83,7 @@ def graph_engine(version: str):
             "opencensus-ext-azure",
             "fsspec>=2021.8.1",
             "scikit-learn",
-            "scipy",
+            "scipy>=1.10.0",
             "tenacity>=8",
         ],
         project_urls={


### PR DESCRIPTION
- [x] Forked repo is synced with upstream -> github shows no code delta outside of the desired.
    https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork
- [x] Tests are passing? https://github.com/microsoft/DeepGNN/blob/main/CONTRIBUTING.md#run-tests
- [x] PR is labeled using the label menu on the right side.

Previous Behavior
----------------
Examples fail to run on mac with "object is not subscriptable" error.

New Behavior
----------------
Explicitly return a row copy for Cora dataset.