### PR TITLE
Fix adl path parsing for graph loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Uniform sampling works in temporal graphs.
+- ADL path parsing to download graph data.
 
 ## [0.1.60] - 2022-04-18
 

--- a/src/python/deepgnn/graph_engine/BUILD
+++ b/src/python/deepgnn/graph_engine/BUILD
@@ -74,6 +74,7 @@ py_test(
     srcs_version = "PY3",
     deps = [
         ":graph_engine",
+        requirement("adlfs"),
         requirement("numpy"),
         requirement("fsspec"),
         requirement("pytest"),

--- a/src/python/deepgnn/graph_engine/_base.py
+++ b/src/python/deepgnn/graph_engine/_base.py
@@ -219,6 +219,7 @@ class Graph(abc.ABC):
 def get_fs(path: str):
     """Get fsspec filesystem object by path."""
     options = infer_storage_options(path)
-    # Remove 'path' from kwargs because it is not supported by all filesystems
+    # Remove 'path'/'host' from kwargs because it is not supported by all filesystems
     del options["path"]
+    del options["host"]
     return fsspec.filesystem(**options), options

--- a/src/python/deepgnn/graph_engine/_base.py
+++ b/src/python/deepgnn/graph_engine/_base.py
@@ -220,6 +220,8 @@ def get_fs(path: str):
     """Get fsspec filesystem object by path."""
     options = infer_storage_options(path)
     # Remove 'path'/'host' from kwargs because it is not supported by all filesystems
-    del options["path"]
-    del options["host"]
+    if "path" in options:
+        del options["path"]
+    if "host" in options:
+        del options["host"]
     return fsspec.filesystem(**options), options

--- a/src/python/deepgnn/graph_engine/test_adl_reader.py
+++ b/src/python/deepgnn/graph_engine/test_adl_reader.py
@@ -1,10 +1,14 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-import pytest
 import os
 import tempfile
+import sys
+
+import pytest
 import numpy as np
+
+from deepgnn.graph_engine._base import get_fs
 from deepgnn.graph_engine._adl_reader import (
     TextFileSplitIterator,
     TextFileIterator,
@@ -481,3 +485,16 @@ def test_local_adl_file_split_iterator(prepare_local_test_files):
     res = np.concatenate(res)
     exp = np.array(["25"])
     np.testing.assert_array_equal(res, exp)
+
+
+def test_adl_path():
+    fs = get_fs("adl://test.azuredatalakestore.net/some/path")
+    assert fs is not None
+
+
+if __name__ == "__main__":
+    sys.exit(
+        pytest.main(
+            [__file__, "--junitxml", os.environ["XML_OUTPUT_FILE"], *sys.argv[1:]]
+        )
+    )


### PR DESCRIPTION
- [x] Forked repo is synced with upstream -> github shows no code delta outside of the desired.
    https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork
- [x] Tests are passing? https://github.com/microsoft/DeepGNN/blob/main/CONTRIBUTING.md#run-tests
- [x] Changelog and documentation updated.
- [x] PR is labeled using the label menu on the right side.

Previous Behavior
----------------
Exception is thrown when an adl path is passed to create a graph.

New Behavior
----------------
Removed offending keys from config dictionary. Authentication can be set via env variables outside of deepgnn.