### PR TITLE
[CI] Setup remote cache on linux

### DIFF
--- a/.github/actions/benchmarks/action.yml
+++ b/.github/actions/benchmarks/action.yml
@@ -4,8 +4,8 @@ runs:
   using: "composite"
   steps:
     - run: |
-        bazel run -c opt src/cc/lib/benchmark:grpc_benchmark --config=linux
-        bazel run -c opt src/cc/lib/benchmark:sampler_benchmark --config=linux
-        bazel run -c opt src/cc/lib/benchmark:neighbor_sampler_benchmark --config=linux
+        bazel run -c opt src/cc/lib/benchmark:grpc_benchmark --config=linux --remote_cache=http://localhost:8080
+        bazel run -c opt src/cc/lib/benchmark:sampler_benchmark --config=linux --remote_cache=http://localhost:8080
+        bazel run -c opt src/cc/lib/benchmark:neighbor_sampler_benchmark --config=linux --remote_cache=http://localhost:8080
       shell: bash
       if: runner.os == 'Linux'

--- a/.github/actions/buildcache/action.yml
+++ b/.github/actions/buildcache/action.yml
@@ -11,5 +11,5 @@ runs:
       if: runner.os == 'Linux'
       run: |
         go install github.com/buchgr/bazel-remote/v2@v2.4.1
-        bazel-remote --azblob.tenant_id=bazelcache --azblob.storage_account=bazelcache --azblob.container_name=cache --azblob.auth_method=shared_key --dir=/tmp/bazelcache --max_size=5 --http_address=localhost:8080 &
+        bazel-remote --azblob.tenant_id=bazelcache --azblob.storage_account=bazelcache --azblob.container_name=cache --azblob.auth_method=shared_key --dir=/tmp/bazelcache --max_size=2 --http_address=localhost:8080 &
         sleep 5 # Give the server time to start

--- a/.github/actions/buildcache/action.yml
+++ b/.github/actions/buildcache/action.yml
@@ -1,0 +1,15 @@
+name: "Build cache"
+description: "Start remote bazel cache proxy to azure storage"
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/setup-go@v4
+      with:
+        go-version: '^1.20.7'
+    - name: Start cache proxy
+      shell: bash
+      if: runner.os == 'Linux'
+      run: |
+        go install github.com/buchgr/bazel-remote/v2@v2.4.1
+        bazel-remote --azblob.tenant_id=bazelcache --azblob.storage_account=bazelcache --azblob.container_name=cache --azblob.auth_method=shared_key --dir=/tmp/bazelcache --max_size=5 --http_address=localhost:8080 &
+        sleep 5 # Give the server time to start

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -6,6 +6,9 @@ runs:
     - run: echo "BAZEL_CONFIG=linux" >> $GITHUB_ENV
       shell: bash
       if: runner.os == 'Linux'
+    - run: echo "REMOTE_CACHE=--remote_cache=http://localhost:8080" >> $GITHUB_ENV
+      shell: bash
+      if: runner.os == 'Linux'
     - run: echo "BAZEL_CONFIG=windows" >> $GITHUB_ENV
       shell: bash
       if: runner.os == 'Windows'
@@ -14,22 +17,22 @@ runs:
       if: runner.os == 'macOS'
 
     - run: |
-        bazel test -c dbg //src/cc/tests:* --test_output=all --test_timeout 30 --config=${{ env.BAZEL_CONFIG }}
+        bazel test -c dbg //src/cc/tests:* --test_output=all --test_timeout 30 --config=${{ env.BAZEL_CONFIG }} ${{ env.REMOTE_CACHE }} --verbose_failures
       shell: bash
       name: run cpp tests
-    - run: bazel test -c dbg //src/python/deepgnn/...:* --jobs 1 --test_output=all --test_timeout 600 --config=${{ env.BAZEL_CONFIG }}
+    - run: bazel test -c dbg //src/python/deepgnn/...:* --jobs 1 --test_output=all --test_timeout 600 --config=${{ env.BAZEL_CONFIG }} ${{ env.REMOTE_CACHE }}  --verbose_failures
       shell: bash
       name: run python tests
     - run: |
-        bazel test -c dbg //examples/pytorch/...:* --jobs 1 --test_output=all --test_timeout 6000 --config=${{ env.BAZEL_CONFIG }}
-        bazel test -c dbg //examples/tensorflow/...:* --jobs 1 --test_output=all --test_timeout 6000 --config=${{ env.BAZEL_CONFIG }}
-        bazel test -c dbg //docs:* --test_output=all --jobs 1 --config=${{ env.BAZEL_CONFIG }}
+        bazel test -c dbg //examples/pytorch/...:* --jobs 1 --test_output=all --test_timeout 6000 --config=${{ env.BAZEL_CONFIG }} ${{ env.REMOTE_CACHE }}  --verbose_failures
+        bazel test -c dbg //examples/tensorflow/...:* --jobs 1 --test_output=all --test_timeout 6000 --config=${{ env.BAZEL_CONFIG }} ${{ env.REMOTE_CACHE }}  --verbose_failures
+        bazel test -c dbg //docs:* --test_output=all --jobs 1 --config=${{ env.BAZEL_CONFIG }} ${{ env.REMOTE_CACHE }}  --verbose_failures
       shell: bash
       name: run python tests in examples and docs folders
       if: runner.os == 'Linux'
     - run: |
-        bazel run -c dbg //docs:make_docs --config=linux
-        bazel build -c dbg src/cc/lib/benchmark:* --config=linux
+        bazel run -c dbg //docs:make_docs --config=linux ${{ env.REMOTE_CACHE }}  --verbose_failures
+        bazel build -c dbg src/cc/lib/benchmark:* --config=linux ${{ env.REMOTE_CACHE }}  --verbose_failures
       shell: bash
       name: build documentation and benchmarks
       if: runner.os == 'Linux'

--- a/.github/actions/wheel/action.yml
+++ b/.github/actions/wheel/action.yml
@@ -15,6 +15,7 @@ runs:
       run: |
         echo "BAZEL_CONFIG=manylinux" >> $GITHUB_ENV
         echo "PLAT_NAME=manylinux1_x86_64" >> $GITHUB_ENV
+        echo "REMOTE_CACHE=--remote_cache=http://localhost:8080" >> $GITHUB_ENV
         sudo mkdir /dt11
         sudo chown $USER /dt11
       shell: bash
@@ -46,7 +47,7 @@ runs:
       shell: bash
       name: Configure env variables for macos
 
-    - run: bazel build -c opt //src/cc/lib:wrapper --config=${{ env.BAZEL_CONFIG }}
+    - run: bazel build -c opt //src/cc/lib:wrapper --config=${{ env.BAZEL_CONFIG }} ${{ env.REMOTE_CACHE }}
       shell: bash
       name: Build shared library
 

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -8,5 +8,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3.5.3
+      - name: Start build cache proxy
+        uses: ./.github/actions/buildcache
+        env:
+          BAZEL_REMOTE_AZBLOB_SHARED_KEY : ${{ secrets.BAZEL_REMOTE_AZBLOB_SHARED_KEY }}
       - name: Run benchmarks
         uses: ./.github/actions/benchmarks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Start build cache proxy
         uses: ./.github/actions/buildcache
         env:
-          BAZEL_CACHE_CONNECTION_STRING : ${{ secrets.BAZEL_CACHE_CONNECTION_STRING }}
+          BAZEL_REMOTE_AZBLOB_SHARED_KEY : ${{ secrets.BAZEL_REMOTE_AZBLOB_SHARED_KEY }}
       - name: Run tests
         uses: ./.github/actions/test
   benchmarks:
@@ -50,7 +50,7 @@ jobs:
       - name: Start build cache proxy
         uses: ./.github/actions/buildcache
         env:
-          BAZEL_CACHE_CONNECTION_STRING : ${{ secrets.BAZEL_CACHE_CONNECTION_STRING }}
+          BAZEL_REMOTE_AZBLOB_SHARED_KEY : ${{ secrets.BAZEL_REMOTE_AZBLOB_SHARED_KEY }}
       - name: Run benchmarks
         uses: ./.github/actions/benchmarks
   wheel:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,10 @@ jobs:
         with:
           name: examples
           path: examples/*
+      - name: Start build cache proxy
+        uses: ./.github/actions/buildcache
+        env:
+          BAZEL_REMOTE_AZBLOB_SHARED_KEY : ${{ secrets.BAZEL_REMOTE_AZBLOB_SHARED_KEY }}
       - name: build wheel
         uses: ./.github/actions/wheel
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,10 @@ jobs:
         uses: actions/setup-python@v4.7.0
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Start build cache proxy
+        uses: ./.github/actions/buildcache
+        env:
+          BAZEL_CACHE_CONNECTION_STRING : ${{ secrets.BAZEL_CACHE_CONNECTION_STRING }}
       - name: Run tests
         uses: ./.github/actions/test
   benchmarks:
@@ -43,6 +47,10 @@ jobs:
     runs-on: "ubuntu-22.04"
     steps:
       - uses: actions/checkout@v3.5.3
+      - name: Start build cache proxy
+        uses: ./.github/actions/buildcache
+        env:
+          BAZEL_CACHE_CONNECTION_STRING : ${{ secrets.BAZEL_CACHE_CONNECTION_STRING }}
       - name: Run benchmarks
         uses: ./.github/actions/benchmarks
   wheel:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,5 +17,9 @@ jobs:
         uses: actions/setup-python@v4.7.0
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Start build cache proxy
+        uses: ./.github/actions/buildcache
+        env:
+          BAZEL_REMOTE_AZBLOB_SHARED_KEY : ${{ secrets.BAZEL_REMOTE_AZBLOB_SHARED_KEY }}
       - name: Run tests
         uses: ./.github/actions/test

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -20,6 +20,10 @@ jobs:
         uses: actions/setup-python@v4.7.0
         with:
           python-version: "3.10"
+      - name: Start build cache proxy
+        uses: ./.github/actions/buildcache
+        env:
+          BAZEL_REMOTE_AZBLOB_SHARED_KEY : ${{ secrets.BAZEL_REMOTE_AZBLOB_SHARED_KEY }}
       - name: build wheel
         uses: ./.github/actions/wheel
         with:


### PR DESCRIPTION
- [x] Forked repo is synced with upstream -> github shows no code delta outside of the desired.
    https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork
- [x] Tests are passing? https://github.com/microsoft/DeepGNN/blob/main/CONTRIBUTING.md#run-tests
- [x] Changelog and documentation updated.
- [x] PR is labeled using the label menu on the right side.

Previous Behavior
----------------
CI pipeline was slow and failing with out of storage errors

New Behavior
----------------
Added [bazel-remote](https://github.com/buchgr/bazel-remote) proxy to store cache in Azure storage blobs and only 2Gb on disk(agents have 10gb available).
Linux is the fastest OS to build now with the most tests: https://github.com/microsoft/DeepGNN/actions/runs/5898231305
