### PR TITLE
Explicitly require secrets in cache action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
       - main
   pull_request:
     types: [opened, reopened, synchronize]
+    secrets:
+      BAZEL_REMOTE_AZBLOB_SHARED_KEY:
+        required: true
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
- [x] Forked repo is synced with upstream -> github shows no code delta outside of the desired.
    https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork
- [x] Tests are passing? https://github.com/microsoft/DeepGNN/blob/main/CONTRIBUTING.md#run-tests

Previous Behavior
----------------
CI triggered from PR didn't pass secrets to cache action

New Behavior
----------------
Explicitly require it.