### PR TITLE
Fix hostname inputs for bazel remote cache.

### DIFF
--- a/.github/actions/benchmarks/action.yml
+++ b/.github/actions/benchmarks/action.yml
@@ -1,5 +1,10 @@
 name: "Benchmarks"
 description: "Run benchmarks"
+inputs:
+  cache_address:
+    description: 'Address of bazel remote cache.'
+    required: true
+    default: http://localhost:8080
 runs:
   using: "composite"
   steps:

--- a/.github/actions/benchmarks/action.yml
+++ b/.github/actions/benchmarks/action.yml
@@ -4,7 +4,7 @@ inputs:
   cache_address:
     description: 'Address of bazel remote cache.'
     required: true
-    default: http://localhost:8080
+    default: localhost:8080
 runs:
   using: "composite"
   steps:

--- a/.github/actions/buildcache/action.yml
+++ b/.github/actions/buildcache/action.yml
@@ -4,7 +4,7 @@ inputs:
   cache_address:
     description: 'Address of bazel remote cache.'
     required: true
-    default: http://localhost:8080
+    default: localhost:8080
 runs:
   using: "composite"
   steps:

--- a/.github/actions/buildcache/action.yml
+++ b/.github/actions/buildcache/action.yml
@@ -1,5 +1,10 @@
 name: "Build cache"
 description: "Start remote bazel cache proxy to azure storage"
+inputs:
+  cache_address:
+    description: 'Address of bazel remote cache.'
+    required: true
+    default: http://localhost:8080
 runs:
   using: "composite"
   steps:
@@ -11,6 +16,6 @@ runs:
       if: runner.os == 'Linux'
       run: |
         go install github.com/buchgr/bazel-remote/v2@v2.4.1
-        bazel-remote --azblob.tenant_id=bazelcache --azblob.storage_account=bazelcache --azblob.container_name=cache --azblob.auth_method=shared_key --dir=/tmp/bazelcache --max_size=2 --http_address=localhost:8080 &
+        bazel-remote --azblob.tenant_id=bazelcache --azblob.storage_account=bazelcache --azblob.container_name=cache --azblob.auth_method=shared_key --dir=/tmp/bazelcache --max_size=2 --http_address=${{ inputs.cache_address }} &
         sleep 5 # Give the server time to start
         echo $(curl ${{ inputs.cache_address }}/status)

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -1,5 +1,10 @@
 name: "Test"
 description: "Run unit tests"
+inputs:
+  cache_address:
+    description: 'Address of bazel remote cache.'
+    required: true
+    default: http://localhost:8080
 runs:
   using: "composite"
   steps:

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -4,7 +4,7 @@ inputs:
   cache_address:
     description: 'Address of bazel remote cache.'
     required: true
-    default: http://localhost:8080
+    default: localhost:8080
 runs:
   using: "composite"
   steps:

--- a/.github/actions/wheel/action.yml
+++ b/.github/actions/wheel/action.yml
@@ -8,7 +8,7 @@ inputs:
   cache_address:
     description: 'Address of bazel remote cache.'
     required: true
-    default: http://localhost:8080
+    default: localhost:8080
 runs:
   using: "composite"
   steps:

--- a/.github/actions/wheel/action.yml
+++ b/.github/actions/wheel/action.yml
@@ -5,6 +5,10 @@ inputs:
     description: 'Package version'
     required: true
     default: '0.1.1'
+  cache_address:
+    description: 'Address of bazel remote cache.'
+    required: true
+    default: http://localhost:8080
 runs:
   using: "composite"
   steps:


### PR DESCRIPTION
- [x] Forked repo is synced with upstream -> github shows no code delta outside of the desired.
    https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork
- [x] Tests are passing? https://github.com/microsoft/DeepGNN/blob/main/CONTRIBUTING.md#run-tests
- [x] Changelog and documentation updated.
- [x] PR is labeled using the label menu on the right side.

Previous Behavior
----------------
No input set.

New Behavior
----------------
Input now set.