### PR TITLE
Revert "Revert Bump transformers from 4.30.2 to 4.36.0"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -257,7 +257,7 @@ torch_geometric==2.3.0
 tornado==6.3.3
 tqdm==4.64.1
 traitlets==5.4.0
-transformers==4.30.2
+transformers==4.36.0
 typeguard==2.13.3
 typing-extensions==4.4.0
 tzdata==2023.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -92,7 +92,7 @@ grpcio-tools==1.49.1
 h5py==3.7.0
 heapdict==1.0.1
 horovod==0.26.0;sys_platform != 'win32'
-huggingface-hub==0.10.1
+huggingface-hub==0.20.2
 idna==3.4
 idna-ssl==1.1.0
 imagesize==1.4.1
@@ -245,7 +245,7 @@ terminado==0.16.0
 testpath==0.6.0
 threadpoolctl==3.1.0
 thrift==0.16.0
-tokenizers==0.13.1
+tokenizers==0.15.0
 toml==0.10.2
 tomli==2.0.1
 toolz==0.12.0
@@ -257,7 +257,7 @@ torch_geometric==2.3.0
 tornado==6.3.3
 tqdm==4.64.1
 traitlets==5.4.0
-transformers==4.36.0
+transformers==4.36.2
 typeguard==2.13.3
 typing-extensions==4.4.0
 tzdata==2023.3


### PR DESCRIPTION
Reverts microsoft/DeepGNN#251

- Includes fix that transformers upgrade introduces.