### PR TITLE
Fix edge feature fetching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.62] - 2024-01-18
+
+### Fixed
+- Fixes edge feature fetching when edges are not sorted by destination id.
+
 ## [0.1.61] - 2022-10-12
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.62] - 2024-01-18
+## [0.1.62] - 2024-01-19
 
 ### Fixed
 - Fixes edge feature fetching when edges are not sorted by destination id.

--- a/src/cc/lib/benchmark/BUILD
+++ b/src/cc/lib/benchmark/BUILD
@@ -25,6 +25,22 @@ cc_binary(
 )
 
 cc_binary(
+    name = "search_benchmark",
+    srcs = ["search_benchmark.cc"],
+    copts = CXX_OPTS,
+    linkopts = ["-lm"],
+    deps = select({
+        "//conditions:default": [
+            "@com_google_benchmark//:benchmark",
+        ],
+        "@platforms//os:linux": [
+            "@mimalloc//:mimalloc",  # mimalloc should go first to ensure malloc is overridden everywhere
+            "@com_google_benchmark//:benchmark",
+        ],
+    }),
+)
+
+cc_binary(
     name = "neighbor_sampler_benchmark",
     srcs = ["neighbor_sampler_benchmark.cc"],
     copts = CXX_OPTS,

--- a/src/cc/lib/benchmark/search_benchmark.cc
+++ b/src/cc/lib/benchmark/search_benchmark.cc
@@ -1,0 +1,68 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include <algorithm>
+#include <iostream>
+#include <numeric>
+#include <random>
+#include <string>
+#include <vector>
+
+#include <benchmark/benchmark.h>
+
+#ifdef SNARK_PLATFORM_LINUX
+#include <mimalloc-override.h>
+#endif
+
+static void BM_LOWER_BOUND(benchmark::State &state)
+{
+    size_t max_count = state.range(0);
+    std::vector<int64_t> elements(max_count);
+    std::iota(elements.begin(), elements.end(), 0);
+    std::vector<int64_t> ids(elements);
+    int64_t seed = 42;
+    std::shuffle(ids.begin(), ids.end(), std::mt19937_64(seed));
+    size_t curr = 0;
+    for (auto _ : state)
+    {
+        ++curr;
+        if (curr == max_count)
+        {
+            curr = 0;
+        }
+        const auto res = std::lower_bound(elements.cbegin(), elements.cend(), ids[curr]);
+        if (*res != ids[curr])
+        {
+            throw std::runtime_error("not found" + std::to_string(ids[curr]) + " got " + std::to_string(*res));
+        }
+    }
+}
+
+static void BM_STD_FIND(benchmark::State &state)
+{
+    size_t max_count = state.range(0);
+    std::vector<int64_t> elements(max_count);
+    std::iota(elements.begin(), elements.end(), 0);
+    std::vector<int64_t> ids(elements);
+    int64_t seed = 42;
+    std::shuffle(ids.begin(), ids.end(), std::mt19937_64(seed));
+    size_t curr = 0;
+    for (auto _ : state)
+    {
+        ++curr;
+        if (curr == max_count)
+        {
+            curr = 0;
+        }
+        const auto res = std::find(elements.cbegin(), elements.cend(), ids[curr]);
+        if (*res != ids[curr])
+        {
+            throw std::runtime_error("not found" + std::to_string(ids[curr]) + " got " + std::to_string(*res));
+        }
+    }
+}
+
+BENCHMARK(BM_LOWER_BOUND)->RangeMultiplier(4)->Range(1 << 3, 1 << 10);
+BENCHMARK(BM_STD_FIND)->RangeMultiplier(4)->Range(1 << 3, 1 << 10);
+
+BENCHMARK_MAIN();

--- a/src/cc/lib/benchmark/search_benchmark.cc
+++ b/src/cc/lib/benchmark/search_benchmark.cc
@@ -2,10 +2,8 @@
 // Licensed under the MIT License.
 
 #include <algorithm>
-#include <iostream>
 #include <numeric>
 #include <random>
-#include <string>
 #include <vector>
 
 #include <benchmark/benchmark.h>
@@ -62,6 +60,7 @@ static void BM_STD_FIND(benchmark::State &state)
     }
 }
 
+// Results of this benchmark are used to set split value for edge feature fetching
 BENCHMARK(BM_LOWER_BOUND)->RangeMultiplier(4)->Range(1 << 3, 1 << 10);
 BENCHMARK(BM_STD_FIND)->RangeMultiplier(4)->Range(1 << 3, 1 << 10);
 

--- a/src/cc/lib/graph/partition.cc
+++ b/src/cc/lib/graph/partition.cc
@@ -914,26 +914,18 @@ std::optional<size_t> Partition::EdgeFeatureOffset(uint64_t internal_src_node_id
     auto lst = fst + tp_count;
 
     // Fast path: linear search outperforms binary search for small number of elements.
-    if (tp_count <= 16)
+    if (tp_count > 16)
     {
-        auto it = std::find(fst, lst, input_edge_dst);
+        auto it = std::lower_bound(fst, lst, input_edge_dst);
         if (it != lst && *it == input_edge_dst)
         {
             return {it - std::begin(m_edge_destination)};
         }
-
-        return std::nullopt;
+        // For temporal graphs we need to use fallback to linear search, since edges are stored based on timestamps
+        // first order or for older graphs with malformed data.
     }
 
-    auto it = std::lower_bound(fst, lst, input_edge_dst);
-    if (it != lst && *it == input_edge_dst)
-    {
-        return {it - std::begin(m_edge_destination)};
-    }
-
-    // For temporal graphs we need to use fallback to linear search, since edges are stored based on timestamps first
-    // order.
-    it = std::find(fst, lst, input_edge_dst);
+    auto it = std::find(fst, lst, input_edge_dst);
     if (it != lst && *it == input_edge_dst)
     {
         return {it - std::begin(m_edge_destination)};

--- a/src/cc/lib/graph/partition.cc
+++ b/src/cc/lib/graph/partition.cc
@@ -908,16 +908,38 @@ std::optional<size_t> Partition::EdgeFeatureOffset(uint64_t internal_src_node_id
     {
         return std::nullopt;
     }
+
     const auto tp_count = m_edge_type_offset[type_offset + 1] - m_edge_type_offset[type_offset];
     auto fst = std::begin(m_edge_destination) + m_edge_type_offset[type_offset];
     auto lst = fst + tp_count;
-    auto it = std::lower_bound(fst, lst, input_edge_dst);
-    if (it == lst)
+
+    // Fast path: linear search outperforms binary search for small number of elements.
+    if (tp_count <= 16)
     {
-        // Edge was not found in this partition.
+        auto it = std::find(fst, lst, input_edge_dst);
+        if (it != lst && *it == input_edge_dst)
+        {
+            return {it - std::begin(m_edge_destination)};
+        }
+
         return std::nullopt;
     }
-    return {it - std::begin(m_edge_destination)};
+
+    auto it = std::lower_bound(fst, lst, input_edge_dst);
+    if (it != lst && *it == input_edge_dst)
+    {
+        return {it - std::begin(m_edge_destination)};
+    }
+
+    // For temporal graphs we need to use fallback to linear search, since edges are stored based on timestamps first
+    // order.
+    it = std::find(fst, lst, input_edge_dst);
+    if (it != lst && *it == input_edge_dst)
+    {
+        return {it - std::begin(m_edge_destination)};
+    }
+
+    return std::nullopt;
 }
 
 void Partition::GetEdgeFeature(uint64_t internal_src_node_id, NodeId input_edge_dst, Type input_edge_type,

--- a/src/cc/tests/graph_test.cc
+++ b/src/cc/tests/graph_test.cc
@@ -12,6 +12,7 @@
 #include <cassert>
 #include <cstdio>
 #include <filesystem>
+#include <fstream>
 #include <span>
 #include <vector>
 
@@ -349,6 +350,117 @@ TEST_P(StorageTypeGraphTest, NodeTypesMultipleNodes)
 
     g.GetNodeType(std::span(nodes), std::span(output), -1);
     EXPECT_EQ(output, std::vector<snark::Type>({0, 2, -1}));
+}
+
+TEST_P(StorageTypeGraphTest, EdgeFeaturesInverseOrder)
+{
+    auto path = std::filesystem::path(::testing::UnitTest::GetInstance()->current_test_info()->name());
+    assert(std::filesystem::create_directories(path));
+    {
+        std::fstream meta_json(path / "meta.json", std::ios::out);
+        meta_json << "{\"node_count\": 2, \"edge_count\": 3, \"node_type_count\": 1, \"edge_type_count\": 2, "
+                     "\"node_feature_count\": 0, \"edge_feature_count\": 1, \"binary_data_version\": \"v2\",";
+        meta_json << "\"partitions\": {\"0\": {\"node_weight\": [5], \"edge_weight\": [0, 10]}}, "
+                     "\"node_count_per_type\": [2],\"edge_count_per_type\": [0, 3],\"watermark\": -1}";
+        std::fstream node_features_index(path / "node_features_0_0.index", std::ios::out);
+        std::fstream node_features_data(path / "node_features_0_0.data", std::ios::out);
+        std::fstream node_index(path / "node_0_0.index", std::ios::out);
+    }
+    {
+        auto filepath = path / "node_0_0.map";
+        auto f = fopen(filepath.c_str(), "wb");
+        int64_t node_id = 4;
+        int32_t node_type = 0;
+        int64_t offset = 0;
+        fwrite(&node_id, sizeof(node_id), 1, f);
+        fwrite(&offset, sizeof(offset), 1, f);
+        fwrite(&node_type, sizeof(node_type), 1, f);
+        node_id = 5;
+        offset = 1;
+        fwrite(&node_id, sizeof(node_id), 1, f);
+        fwrite(&offset, sizeof(offset), 1, f);
+        fwrite(&node_type, sizeof(node_type), 1, f);
+        fclose(f);
+    }
+    {
+        auto filepath = path / "neighbors_0_0.index";
+        auto f = fopen(filepath.c_str(), "wb");
+        int64_t offset = 0;
+        fwrite(&offset, sizeof(offset), 1, f);
+        offset = 0; // no edges in the first node. original offset - current offset = 0
+        fwrite(&offset, sizeof(offset), 1, f);
+        offset = 3; // 3 edges in the last node.
+        fwrite(&offset, sizeof(offset), 1, f);
+        fclose(f);
+    }
+    {
+        struct EdgeRecord
+        {
+            int64_t m_dst;
+            uint64_t m_feature_offset;
+            int32_t m_type;
+            float m_weight;
+        };
+        auto filepath = path / "edge_0_0.index";
+        auto f = fopen(filepath.c_str(), "wb");
+        EdgeRecord edge{.m_dst = 4, .m_feature_offset = 0, .m_type = 1, .m_weight = 1.0f};
+        fwrite(&edge, sizeof(edge), 1, f);
+        edge = {.m_dst = 2, .m_feature_offset = 2, .m_type = 1, .m_weight = 0.5f};
+        fwrite(&edge, sizeof(edge), 1, f);
+        edge = {.m_dst = 3, .m_feature_offset = 3, .m_type = 1, .m_weight = 1.0f};
+        fwrite(&edge, sizeof(edge), 1, f);
+        // Finish with stub for feature size calculation
+        edge = {.m_dst = -1, .m_feature_offset = 4, .m_type = 1, .m_weight = 1.0f};
+        fwrite(&edge, sizeof(edge), 1, f);
+        fclose(f);
+    }
+
+    {
+        auto filepath = path / "edge_features_0_0.index";
+        auto f = fopen(filepath.c_str(), "wb");
+        int64_t offset = 0;
+        fwrite(&offset, sizeof(offset), 1, f);
+        offset = 0; // no edges of type 0
+        fwrite(&offset, sizeof(offset), 1, f);
+        offset = 12;
+        fwrite(&offset, sizeof(offset), 1, f);
+        offset = 24;
+        fwrite(&offset, sizeof(offset), 1, f);
+        offset = 36;
+        fwrite(&offset, sizeof(offset), 1, f);
+        fclose(f);
+    }
+
+    {
+        auto filepath = path / "edge_features_0_0.data";
+        auto f = fopen(filepath.c_str(), "wb");
+        struct Values
+        {
+            int32_t a;
+            int32_t b;
+            int32_t c;
+        } vals;
+        vals = {8, 9, 10};
+        fwrite(&vals, sizeof(vals), 1, f);
+        vals = {5, 6, 7};
+        fwrite(&vals, sizeof(vals), 1, f);
+        vals = {1, 2, 3};
+        fwrite(&vals, sizeof(vals), 1, f);
+        fclose(f);
+    }
+
+    snark::Metadata metadata(path.string());
+    snark::Graph g(std::move(metadata), {path.string()}, std::vector<uint32_t>{0}, GetParam());
+    std::vector<snark::NodeId> src_ids = {5, 5, 5};
+    std::vector<snark::NodeId> dst_ids = {2, 3, 5};
+    std::vector<snark::Type> edge_types = {1, 1, 1};
+    std::vector<uint8_t> output(4 * 3 * 3);
+    std::vector<snark::FeatureMeta> features = {{0, 12}};
+
+    g.GetEdgeFeature(std::span(src_ids), std::span(dst_ids), std::span(edge_types), {}, std::span(features),
+                     std::span(output));
+    std::span res(reinterpret_cast<int32_t *>(output.data()), output.size() / sizeof(int32_t));
+    EXPECT_EQ(std::vector<int32_t>(std::begin(res), std::end(res)), std::vector<int32_t>({5, 6, 7, 1, 2, 3, 0, 0, 0}));
 }
 
 TEST_P(StorageTypeGraphTest, NodeFeaturesMultipleNodesSingleFeature)

--- a/src/cc/tests/graph_test.cc
+++ b/src/cc/tests/graph_test.cc
@@ -368,7 +368,7 @@ TEST_P(StorageTypeGraphTest, EdgeFeaturesInverseOrder)
     }
     {
         auto filepath = path / "node_0_0.map";
-        auto f = fopen(filepath.c_str(), "wb");
+        auto f = fopen(reinterpret_cast<const char *>(filepath.c_str()), "wb");
         int64_t node_id = 4;
         int32_t node_type = 0;
         int64_t offset = 0;
@@ -384,7 +384,7 @@ TEST_P(StorageTypeGraphTest, EdgeFeaturesInverseOrder)
     }
     {
         auto filepath = path / "neighbors_0_0.index";
-        auto f = fopen(filepath.c_str(), "wb");
+        auto f = fopen(reinterpret_cast<const char *>(filepath.c_str()), "wb");
         int64_t offset = 0;
         fwrite(&offset, sizeof(offset), 1, f);
         offset = 0; // no edges in the first node. original offset - current offset = 0
@@ -402,7 +402,7 @@ TEST_P(StorageTypeGraphTest, EdgeFeaturesInverseOrder)
             float m_weight;
         };
         auto filepath = path / "edge_0_0.index";
-        auto f = fopen(filepath.c_str(), "wb");
+        auto f = fopen(reinterpret_cast<const char *>(filepath.c_str()), "wb");
         EdgeRecord edge{.m_dst = 4, .m_feature_offset = 0, .m_type = 1, .m_weight = 1.0f};
         fwrite(&edge, sizeof(edge), 1, f);
         edge = {.m_dst = 2, .m_feature_offset = 2, .m_type = 1, .m_weight = 0.5f};
@@ -417,7 +417,7 @@ TEST_P(StorageTypeGraphTest, EdgeFeaturesInverseOrder)
 
     {
         auto filepath = path / "edge_features_0_0.index";
-        auto f = fopen(filepath.c_str(), "wb");
+        auto f = fopen(reinterpret_cast<const char *>(filepath.c_str()), "wb");
         int64_t offset = 0;
         fwrite(&offset, sizeof(offset), 1, f);
         offset = 0; // no edges of type 0
@@ -433,7 +433,7 @@ TEST_P(StorageTypeGraphTest, EdgeFeaturesInverseOrder)
 
     {
         auto filepath = path / "edge_features_0_0.data";
-        auto f = fopen(filepath.c_str(), "wb");
+        auto f = fopen(reinterpret_cast<const char *>(filepath.c_str()), "wb");
         struct Values
         {
             int32_t a;

--- a/src/cc/tests/graph_test.cc
+++ b/src/cc/tests/graph_test.cc
@@ -368,30 +368,27 @@ TEST_P(StorageTypeGraphTest, EdgeFeaturesInverseOrder)
     }
     {
         auto filepath = path / "node_0_0.map";
-        auto f = fopen(reinterpret_cast<const char *>(filepath.c_str()), "wb");
+        std::fstream f(path / "node_0_0.map", std::ios_base::binary | std::ios_base::out);
         int64_t node_id = 4;
         int32_t node_type = 0;
         int64_t offset = 0;
-        fwrite(&node_id, sizeof(node_id), 1, f);
-        fwrite(&offset, sizeof(offset), 1, f);
-        fwrite(&node_type, sizeof(node_type), 1, f);
+        f.write(reinterpret_cast<const char *>(&node_id), sizeof(node_id));
+        f.write(reinterpret_cast<const char *>(&offset), sizeof(offset));
+        f.write(reinterpret_cast<const char *>(&node_type), sizeof(node_type));
         node_id = 5;
         offset = 1;
-        fwrite(&node_id, sizeof(node_id), 1, f);
-        fwrite(&offset, sizeof(offset), 1, f);
-        fwrite(&node_type, sizeof(node_type), 1, f);
-        fclose(f);
+        f.write(reinterpret_cast<const char *>(&node_id), sizeof(node_id));
+        f.write(reinterpret_cast<const char *>(&offset), sizeof(offset));
+        f.write(reinterpret_cast<const char *>(&node_type), sizeof(node_type));
     }
     {
-        auto filepath = path / "neighbors_0_0.index";
-        auto f = fopen(reinterpret_cast<const char *>(filepath.c_str()), "wb");
+        std::fstream f(path / "neighbors_0_0.index", std::ios_base::binary | std::ios_base::out);
         int64_t offset = 0;
-        fwrite(&offset, sizeof(offset), 1, f);
+        f.write(reinterpret_cast<const char *>(&offset), sizeof(offset));
         offset = 0; // no edges in the first node. original offset - current offset = 0
-        fwrite(&offset, sizeof(offset), 1, f);
+        f.write(reinterpret_cast<const char *>(&offset), sizeof(offset));
         offset = 3; // 3 edges in the last node.
-        fwrite(&offset, sizeof(offset), 1, f);
-        fclose(f);
+        f.write(reinterpret_cast<const char *>(&offset), sizeof(offset));
     }
     {
         struct EdgeRecord
@@ -401,39 +398,34 @@ TEST_P(StorageTypeGraphTest, EdgeFeaturesInverseOrder)
             int32_t m_type;
             float m_weight;
         };
-        auto filepath = path / "edge_0_0.index";
-        auto f = fopen(reinterpret_cast<const char *>(filepath.c_str()), "wb");
+        std::fstream f(path / "edge_0_0.index", std::ios_base::binary | std::ios_base::out);
         EdgeRecord edge{.m_dst = 4, .m_feature_offset = 0, .m_type = 1, .m_weight = 1.0f};
-        fwrite(&edge, sizeof(edge), 1, f);
+        f.write(reinterpret_cast<const char *>(&edge), sizeof(edge));
         edge = {.m_dst = 2, .m_feature_offset = 2, .m_type = 1, .m_weight = 0.5f};
-        fwrite(&edge, sizeof(edge), 1, f);
+        f.write(reinterpret_cast<const char *>(&edge), sizeof(edge));
         edge = {.m_dst = 3, .m_feature_offset = 3, .m_type = 1, .m_weight = 1.0f};
-        fwrite(&edge, sizeof(edge), 1, f);
+        f.write(reinterpret_cast<const char *>(&edge), sizeof(edge));
         // Finish with stub for feature size calculation
         edge = {.m_dst = -1, .m_feature_offset = 4, .m_type = 1, .m_weight = 1.0f};
-        fwrite(&edge, sizeof(edge), 1, f);
-        fclose(f);
+        f.write(reinterpret_cast<const char *>(&edge), sizeof(edge));
     }
 
     {
-        auto filepath = path / "edge_features_0_0.index";
-        auto f = fopen(reinterpret_cast<const char *>(filepath.c_str()), "wb");
+        std::fstream f(path / "edge_features_0_0.index", std::ios_base::binary | std::ios_base::out);
         int64_t offset = 0;
-        fwrite(&offset, sizeof(offset), 1, f);
+        f.write(reinterpret_cast<const char *>(&offset), sizeof(offset));
         offset = 0; // no edges of type 0
-        fwrite(&offset, sizeof(offset), 1, f);
+        f.write(reinterpret_cast<const char *>(&offset), sizeof(offset));
         offset = 12;
-        fwrite(&offset, sizeof(offset), 1, f);
+        f.write(reinterpret_cast<const char *>(&offset), sizeof(offset));
         offset = 24;
-        fwrite(&offset, sizeof(offset), 1, f);
+        f.write(reinterpret_cast<const char *>(&offset), sizeof(offset));
         offset = 36;
-        fwrite(&offset, sizeof(offset), 1, f);
-        fclose(f);
+        f.write(reinterpret_cast<const char *>(&offset), sizeof(offset));
     }
 
     {
-        auto filepath = path / "edge_features_0_0.data";
-        auto f = fopen(reinterpret_cast<const char *>(filepath.c_str()), "wb");
+        std::fstream f(path / "edge_features_0_0.data", std::ios_base::binary | std::ios_base::out);
         struct Values
         {
             int32_t a;
@@ -441,12 +433,11 @@ TEST_P(StorageTypeGraphTest, EdgeFeaturesInverseOrder)
             int32_t c;
         } vals;
         vals = {8, 9, 10};
-        fwrite(&vals, sizeof(vals), 1, f);
+        f.write(reinterpret_cast<const char *>(&vals), sizeof(vals));
         vals = {5, 6, 7};
-        fwrite(&vals, sizeof(vals), 1, f);
+        f.write(reinterpret_cast<const char *>(&vals), sizeof(vals));
         vals = {1, 2, 3};
-        fwrite(&vals, sizeof(vals), 1, f);
-        fclose(f);
+        f.write(reinterpret_cast<const char *>(&vals), sizeof(vals));
     }
 
     snark::Metadata metadata(path.string());

--- a/src/python/deepgnn/graph_engine/snark/decoders.py
+++ b/src/python/deepgnn/graph_engine/snark/decoders.py
@@ -417,6 +417,7 @@ class JsonDecoder(Decoder):
                     edge.get("removed_at", 0)
                     if edge.get("removed_at") != -1
                     else float("inf"),
+                    edge["dst_id"],
                 ),
             )
 
@@ -526,7 +527,12 @@ class TsvDecoder(Decoder):
             return
 
         neighbors = columns[4].split("|")
-        for n in sorted(neighbors, key=lambda x: int(x.split(",")[1])):
+
+        def order(edge):
+            edge_items = edge.split(",")
+            return int(edge_items[1]), int(edge_items[0])
+
+        for n in sorted(neighbors, key=order):
             neighbor_columns = n.split(",")
             # make sure the destination id is valid
             assert len(neighbor_columns) > 0 and len(neighbor_columns[0]) > 0

--- a/src/python/deepgnn/graph_engine/snark/tests/convert_test.py
+++ b/src/python/deepgnn/graph_engine/snark/tests/convert_test.py
@@ -1431,6 +1431,93 @@ def test_edge_index_inverted_types(graph_with_inverse_edge_type_order):
         assert result[68:72] == struct.pack("f", -1)
 
 
+def graph_with_inverse_edge_dst_order_json(folder):
+    data = open(os.path.join(folder, "graph.json"), "w+")
+    graph = [
+        {
+            "node_id": 9,
+            "node_type": 0,
+            "node_weight": 1,
+            "edge": [
+                {
+                    "src_id": 9,
+                    "dst_id": 2,
+                    "edge_type": 1,
+                    "weight": 1.0,
+                },
+                {
+                    "src_id": 9,
+                    "dst_id": 1,
+                    "edge_type": 1,
+                    "weight": 0.5,
+                },
+            ],
+        },
+    ]
+    for el in graph:
+        json.dump(el, data)
+        data.write("\n")
+    data.flush()
+    data.close()
+
+    return data.name
+
+
+def graph_with_inverse_edge_dst_order_tsv(folder):
+    data = open(os.path.join(folder, "graph.tsv"), "w+")
+    data.write("9\t0\t1\tf:0 1;f:-0.01 -0.02\t2,1,1.0|1,1,0.5\n")
+    data.flush()
+    data.close()
+    return data.name
+
+
+@pytest.fixture(scope="module")
+def graph_with_inverse_edge_dst_order(request):
+    workdir = tempfile.TemporaryDirectory()
+    if request.param == JsonDecoder:
+        data_name = graph_with_inverse_edge_dst_order_json(workdir.name)
+    elif request.param == TsvDecoder:
+        data_name = graph_with_inverse_edge_dst_order_tsv(workdir.name)
+    else:
+        raise ValueError("Unsupported format.")
+
+    yield data_name, request.param
+    workdir.cleanup()
+
+
+@pytest.mark.parametrize(
+    "graph_with_inverse_edge_dst_order", [JsonDecoder, TsvDecoder], indirect=True
+)
+def test_edge_index_inverted_dst(graph_with_inverse_edge_dst_order):
+    output = tempfile.TemporaryDirectory()
+    data_name, decoder = graph_with_inverse_edge_dst_order
+    convert.MultiWorkersConverter(
+        graph_path=data_name,
+        partition_count=1,
+        output_dir=output.name,
+        decoder=decoder(),
+        debug=True,
+    ).convert()
+    with open("{}/edge_{}_{}.index".format(output.name, 0, 0), "rb") as ei:
+        expected_size = 3 * 24  # 2 edges + last line as final close
+        result = ei.read(expected_size + 100)
+        assert len(result) == expected_size
+        assert result[0:8] == (1).to_bytes(8, byteorder=sys.byteorder)
+        assert result[8:16] == (0).to_bytes(8, byteorder=sys.byteorder)
+        assert result[16:20] == (1).to_bytes(4, byteorder=sys.byteorder)
+        assert result[20:24] == struct.pack("f", 0.5)
+
+        assert result[24:32] == (2).to_bytes(8, byteorder=sys.byteorder)
+        assert result[32:40] == (0).to_bytes(8, byteorder=sys.byteorder)
+        assert result[40:44] == (1).to_bytes(4, byteorder=sys.byteorder)
+        assert result[44:48] == struct.pack("f", 1.0)
+
+        assert result[48:56] == (0).to_bytes(8, byteorder=sys.byteorder)
+        assert result[56:64] == (0).to_bytes(8, byteorder=sys.byteorder)
+        assert result[64:68] == (0).to_bytes(4, byteorder=sys.byteorder)
+        assert result[68:72] == struct.pack("f", -1)
+
+
 if __name__ == "__main__":
     sys.exit(
         pytest.main(


### PR DESCRIPTION
- [x] Forked repo is synced with upstream -> github shows no code delta outside of the desired.
    https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork
- [x] Tests are passing? https://github.com/microsoft/DeepGNN/blob/main/CONTRIBUTING.md#run-tests
- [x] Changelog and documentation updated.
- [x] PR is labeled using the label menu on the right side.

Previous Behavior
----------------
If edges were not sorted, then we failed to fetch edge features in cases where binary search will not find a correct destination.

New Behavior
----------------
1. Sort edges by destination in a converter for non-temporal graphs.
2. Fallback to linear search, when binary search does not find anything.