### PR TITLE
Increase timeout

### DIFF
--- a/.pipelines/ci.yml
+++ b/.pipelines/ci.yml
@@ -4,6 +4,7 @@ trigger:
     - '*'
 jobs:
 - job: sanity_checks
+  timeoutInMinutes: 120
   pool:
     vmImage: 'windows-latest'
   steps:


### PR DESCRIPTION
- [x] Forked repo is synced with upstream -> github shows no code delta outside of the desired.
    https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork
- [x] Tests are passing? https://github.com/microsoft/DeepGNN/blob/main/CONTRIBUTING.md#run-tests
- [x] PR is labeled using the label menu on the right side.

New Behavior
----------------
Increased timeout for azure devops. Somehow main branch takes much longer than others.