### PR TITLE
[Feature] Make DeepGNN snark server feature loading skippable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Make DeepGNN snark server feature loading skippable
+
 ## [0.1.63] - 2024-05-10
 
 ### Fixed

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,6 @@
 alabaster==0.7.12
 babel==2.10.3
-certifi==2023.7.22
+certifi==2024.7.4
 chardet==3.0.4
 charset-normalizer==2.1.1
 docutils==0.18.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -43,7 +43,7 @@ boto3==1.24.89
 botocore==1.27.89
 cached-property==1.5.2
 cachetools==5.2.0
-certifi==2023.7.22
+certifi==2024.7.4
 cffi==1.15.1
 chardet==5.0.0
 charset-normalizer==2.1.1

--- a/src/cc/lib/graph/metadata.cc
+++ b/src/cc/lib/graph/metadata.cc
@@ -16,8 +16,8 @@ using json = nlohmann::json;
 namespace snark
 {
 
-Metadata::Metadata(std::filesystem::path path, std::string config_path, std::shared_ptr<Logger> logger,
-                   bool skip_feature_loading)
+Metadata::Metadata(std::filesystem::path path, std::string config_path, bool skip_feature_loading,
+                   std::shared_ptr<Logger> logger)
     : m_version(MINIMUM_SUPPORTED_VERSION), m_path(path.string()), m_config_path(config_path), m_watermark(-1)
 {
 

--- a/src/cc/lib/graph/metadata.h
+++ b/src/cc/lib/graph/metadata.h
@@ -18,8 +18,8 @@ const size_t MINIMUM_SUPPORTED_VERSION = 2;
 struct Metadata
 {
     Metadata() = default;
-    explicit Metadata(std::filesystem::path path, std::string config_path = "",
-                      std::shared_ptr<Logger> logger = nullptr, bool skip_feature_loading = false);
+    explicit Metadata(std::filesystem::path path, std::string config_path = "", bool skip_feature_loading = false,
+                      std::shared_ptr<Logger> logger = nullptr);
     void Write(std::filesystem::path path) const;
 
     // Graph information.

--- a/src/cc/lib/py_graph.h
+++ b/src/cc/lib/py_graph.h
@@ -85,7 +85,7 @@ extern "C"
                                            uint32_t *partition_indices, const char **partition_locations,
                                            const char *host_name, const char *ssl_key, const char *ssl_cert,
                                            const char *ssl_root, const PyPartitionStorageType storage_type,
-                                           const char *config_path);
+                                           const char *config_path, bool skip_feature_loading);
 
     DEEPGNN_DLL extern int32_t CreateRemoteClient(PyGraph *graph, const char *output_folder, const char **connection,
                                                   size_t connection_count, const char *ssl_cert, size_t num_threads,

--- a/src/cc/lib/py_server.cc
+++ b/src/cc/lib/py_server.cc
@@ -35,7 +35,7 @@ int32_t StartServer(PyServer *graph, const char *meta_location, size_t count, ui
                     bool skip_feature_loading)
 {
     snark::PartitionStorageType storage_type = static_cast<snark::PartitionStorageType>(storage_type_);
-    snark::Metadata metadata(safe_convert(meta_location), safe_convert(config_path), nullptr, skip_feature_loading);
+    snark::Metadata metadata(safe_convert(meta_location), safe_convert(config_path), skip_feature_loading);
     std::vector<std::string> partition_paths;
     partition_paths.reserve(count);
     for (size_t i = 0; i < count; ++i)

--- a/src/cc/lib/py_server.cc
+++ b/src/cc/lib/py_server.cc
@@ -31,10 +31,17 @@ std::string safe_convert(const char *buffer)
 
 int32_t StartServer(PyServer *graph, const char *meta_location, size_t count, uint32_t *partition_indices,
                     const char **partition_locations, const char *host_name, const char *ssl_key, const char *ssl_cert,
-                    const char *ssl_root, const PyPartitionStorageType storage_type_, const char *config_path)
+                    const char *ssl_root, const PyPartitionStorageType storage_type_, const char *config_path,
+                    bool skip_feature_loading)
 {
     snark::PartitionStorageType storage_type = static_cast<snark::PartitionStorageType>(storage_type_);
     snark::Metadata metadata(safe_convert(meta_location), safe_convert(config_path));
+    // Skip feature loading if requested. This is useful when the feature loading is done in a separate feature store.
+    if (skip_feature_loading == true)
+    {
+        metadata.m_node_feature_count = 0;
+        metadata.m_edge_feature_count = 0;
+    }
     std::vector<std::string> partition_paths;
     partition_paths.reserve(count);
     for (size_t i = 0; i < count; ++i)

--- a/src/python/deepgnn/graph_engine/snark/tests/hdfs_test.py
+++ b/src/python/deepgnn/graph_engine/snark/tests/hdfs_test.py
@@ -93,6 +93,49 @@ def test_hdfs_remote(hdfs_data):
     npt.assert_array_equal(t, [0, 0, 0, 0, 0])
 
 
+def test_hdfs_remote_skip_feature_loading(hdfs_data):
+    repo_dir = os.getcwd().split("/sandbox")[0]
+    if os.path.exists(f"{repo_dir}/bazel-snark"):
+        hadoop_home = f"{repo_dir}/bazel-snark"
+    elif os.path.exists(f"{repo_dir}/bazel-s"):
+        hadoop_home = f"{repo_dir}/bazel-s"
+    else:
+        hadoop_home = f"{repo_dir.split('/bazel-out')[0]}"
+    os.environ["HADOOP_HOME"] = f"{hadoop_home}/external/hadoop/"
+    if "CLASSPATH" in os.environ:
+        del os.environ["CLASSPATH"]
+
+    address = ["localhost:9999"]
+    location = "file://" + hdfs_data
+    s = server.Server(
+        location,
+        [(location, 0)],
+        address[0],
+        config_path="",
+        stream=True,
+        skip_feature_loading=True,
+    )
+    cl = client.DistributedGraph(address)
+
+    v = cl.node_types(np.array([1, 2, 3], dtype=np.int64), default_type=-1)
+    npt.assert_equal(v, np.array([0, 0, 0], dtype=np.int32))
+
+    v = cl.node_features(
+        np.array(range(12), dtype=np.int64),
+        features=np.array([[1, 1]], dtype=np.int32),
+        dtype=np.float32,
+    )
+    npt.assert_equal(
+        v.flatten(),
+        np.array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]),
+    )
+
+    ns = client.NodeSampler(cl, [0, 2])
+    v, t = ns.sample(size=5, seed=2)
+    npt.assert_array_equal(v, [807, 72, 216, 1921, 1849])
+    npt.assert_array_equal(t, [0, 0, 0, 0, 0])
+
+
 def test_streaming_storage_args(hdfs_data):
     repo_dir = os.environ["TEST_SRCDIR"].split("/sandbox")[0]
     if os.path.exists(f"{repo_dir}/bazel-snark"):


### PR DESCRIPTION
Fix #296 

We propose adding a flag to the DeepGNN Snark Server that allows us to opt out of loading node/edge features without modifying the meta.json. This approach will enable us to conduct A/B testing and canary deployments more efficiently.

This can help reduce the amount of memory on our Snark server machine and fit a much bigger compute graph.

- [x] Forked repo is synced with upstream -> github shows no code delta outside of the desired.
    https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork
- [x] Tests are passing? https://github.com/microsoft/DeepGNN/blob/main/CONTRIBUTING.md#run-tests
- [x] Changelog and documentation updated.
- [x] PR is labeled using the label menu on the right side. (I don't have permission)



Previous Behavior
----------------
* Snark server loading all files based on `meta.json`

New Behavior
----------------
* Snark server can skip node/edge feature loading using the new snark flag `--skip_feature_loading`
