### PR TITLE
Fix hdfs unit test with a different server port.

### DIFF
--- a/src/python/deepgnn/graph_engine/snark/tests/hdfs_test.py
+++ b/src/python/deepgnn/graph_engine/snark/tests/hdfs_test.py
@@ -67,7 +67,7 @@ def test_hdfs_remote(hdfs_data):
     if "CLASSPATH" in os.environ:
         del os.environ["CLASSPATH"]
 
-    address = ["localhost:9999"]
+    address = ["localhost:10000"]
     location = "file://" + hdfs_data
     s = server.Server(
         location, [(location, 0)], address[0], config_path="", stream=True


### PR DESCRIPTION
The unit test I introduced in #297 has some conflicts/race condition when using the same server port from the other unit tests. This PR just make the unit test to use a different port to avoid the possible conflicts.

- [x] Forked repo is synced with upstream -> github shows no code delta outside of the desired.
    https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork
- [x] Tests are passing? https://github.com/microsoft/DeepGNN/blob/main/CONTRIBUTING.md#run-tests
- [x] Changelog and documentation updated.
- [ ] PR is labeled using the label menu on the right side. (no permission)

Previous Behavior
----------------
CI sometimes has conflicts during unit test.

New Behavior
----------------
CI can run the two unit tests in parallel without conflicts.