### PR TITLE
Disable macos-12 in CI.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10"]
-        os: ["ubuntu-22.04", "macos-12", "windows-2019"]
+        os: ["ubuntu-22.04", "windows-2019"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3.5.3
@@ -31,7 +31,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.10"]
-        os: ["ubuntu-22.04", "macos-12", "windows-2019"]
+        os: ["ubuntu-22.04", "windows-2019"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3.5.3

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10"]
-        os: ["ubuntu-22.04", "macos-12", "windows-2022"]
+        os: ["ubuntu-22.04", "windows-2022"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3.5.3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.10"]
-        os: ["ubuntu-22.04", "macos-12", "windows-2019"]
+        os: ["ubuntu-22.04", "windows-2019"]
     steps:
       - uses: actions/checkout@v3.5.3
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ["ubuntu-22.04", "macos-12", "windows-2019"]
+        os: ["ubuntu-22.04", "windows-2019"]
     steps:
       - uses: actions/checkout@v3.5.3
       - name: Set up Python 3.10


### PR DESCRIPTION
- [x] Forked repo is synced with upstream -> github shows no code delta outside of the desired.
    https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork
- [x] Tests are passing? https://github.com/microsoft/DeepGNN/blob/main/CONTRIBUTING.md#run-tests
- [x] Changelog and documentation updated.
- [x] PR is labeled using the label menu on the right side.

Previous Behavior
----------------
* Github blocked macos-12 version, clang updates block us from easily updating version.

New Behavior
----------------
Disable mac for short term.