### PR TITLE
Deprecate old custom datasets.

### DIFF
--- a/src/python/deepgnn/graph_engine/data/mooc.py
+++ b/src/python/deepgnn/graph_engine/data/mooc.py
@@ -21,6 +21,10 @@ from deepgnn.graph_engine.snark.local import Client
 class MOOC(Client):
     """Temporal MOOC dataset.
 
+    OUT OF SUPPORT - Dataset loading needs to be modified for deepgnn loading.
+
+    https://snap.stanford.edu/data/act-mooc.html
+
     The graph is a student interaction network formed from online course content units
     like problem sets and videos. Each edge represents a student interacting with a content
     unit and has 4 features. Graph Statistics:
@@ -41,7 +45,7 @@ class MOOC(Client):
             output_dir (Optional[str]): Path to the directory where the graph data will be saved.
                 If None, a temporary directory is used.
         """
-        self.url = "https://deepgraphpub.blob.core.windows.net/public/testdata/mooc.zip"
+        self.url = "https://snap.stanford.edu/data/act-mooc.tar.gz"
         self.GRAPH_NAME = "mooc"
 
         if output_dir is None:
@@ -172,7 +176,7 @@ class MOOC(Client):
         the graph using the BinaryWriter. The graph is written to the output directory.
         """
         raw_data_dir = os.path.join(self.output_dir, "raw")
-        download_file(self.url, raw_data_dir, f"{self.GRAPH_NAME}.zip")
+        download_file(self.url, raw_data_dir, f"{self.GRAPH_NAME}.tar.gz")
         fname = os.path.join(raw_data_dir, f"{self.GRAPH_NAME}.zip")
         with zipfile.ZipFile(fname) as z:
             z.extractall(raw_data_dir)

--- a/src/python/deepgnn/graph_engine/data/test_graph_dataset.py
+++ b/src/python/deepgnn/graph_engine/data/test_graph_dataset.py
@@ -204,6 +204,7 @@ def test_ppi():
     check_label()
 
 
+@pytest.mark.skip(reason="Deprecated.")
 def test_mooc():
     g = MOOC()
     features = g.edge_features(

--- a/src/python/deepgnn/pytorch/encoding/test_feature_encoder.py
+++ b/src/python/deepgnn/pytorch/encoding/test_feature_encoder.py
@@ -208,6 +208,7 @@ def verify_twinbert_encoder_complex_input(config_file):
         verify_encode(context, expect)
 
 
+@pytest.mark.skip(reason="Deprecated")
 def test_twinbert_encoder_simple_input_string_features_pooler_0(
     prepare_local_test_files,
 ):
@@ -221,6 +222,7 @@ def test_twinbert_encoder_simple_input_string_features_pooler_0(
     )
 
 
+@pytest.mark.skip(reason="Deprecated")
 def test_twinbert_encoder_simple_input_string_features_pooler_1(
     prepare_local_test_files,
 ):
@@ -236,6 +238,7 @@ def test_twinbert_encoder_simple_input_string_features_pooler_1(
     )
 
 
+@pytest.mark.skip(reason="Deprecated")
 def test_twinbert_encoder_simple_input_int_features(prepare_local_test_files):
     verify_twinbert_encoder_simple_input(
         os.path.join(prepare_local_test_files, "twinbert", "twinbert_triletter.json"),
@@ -247,6 +250,7 @@ def test_twinbert_encoder_simple_input_int_features(prepare_local_test_files):
     )
 
 
+@pytest.mark.skip(reason="Deprecated")
 def test_twinbert_encoder_complex_input(prepare_local_test_files):
     verify_twinbert_encoder_complex_input(
         os.path.join(prepare_local_test_files, "twinbert", "twinbert_triletter.json")

--- a/src/python/deepgnn/pytorch/encoding/twinbert/test_encoder.py
+++ b/src/python/deepgnn/pytorch/encoding/twinbert/test_encoder.py
@@ -153,6 +153,7 @@ def validate_twinbert_with_wordpiece(
     )
 
 
+@pytest.mark.skip(reason="Deprecated")
 def test_twinbert_with_triletter(prepare_local_test_files):
     infile = os.path.join(prepare_local_test_files, "twinbert", "infile.tsv")
     emb_prefix = os.path.join(
@@ -163,6 +164,7 @@ def test_twinbert_with_triletter(prepare_local_test_files):
     )
 
 
+@pytest.mark.skip(reason="Deprecated")
 def test_twinbert_with_wordpiece(prepare_local_test_files):
     infile = os.path.join(prepare_local_test_files, "twinbert", "infile.tsv")
     emb_prefix = os.path.join(

--- a/src/python/deepgnn/pytorch/encoding/twinbert/test_tokenization.py
+++ b/src/python/deepgnn/pytorch/encoding/twinbert/test_tokenization.py
@@ -23,7 +23,7 @@ def prepare_local_test_files():
     yield working_dir.name
     working_dir.cleanup()
 
-
+@pytest.mark.skip(reason="Deprecated")
 def test_stdberttokenizer(prepare_local_test_files):
     sentence = "hello world"
     tokenizer = StdBertTokenizer(
@@ -34,6 +34,7 @@ def test_stdberttokenizer(prepare_local_test_files):
     assert mask == [1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
 
 
+@pytest.mark.skip(reason="Deprecated")
 def test_trilettertokenizer(prepare_local_test_files):
     sentence = "hello world"
     tokenizer = TriLetterTokenizer(

--- a/src/python/deepgnn/pytorch/encoding/twinbert/test_tokenization.py
+++ b/src/python/deepgnn/pytorch/encoding/twinbert/test_tokenization.py
@@ -23,6 +23,7 @@ def prepare_local_test_files():
     yield working_dir.name
     working_dir.cleanup()
 
+
 @pytest.mark.skip(reason="Deprecated")
 def test_stdberttokenizer(prepare_local_test_files):
     sentence = "hello world"


### PR DESCRIPTION
These are datasets customized behind the scenes, we do not have time budget to convert our reading to use the original snap datasets.