### PR TITLE
[FEATURE] Add skip temporal loading flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Make DeepGNN snark server watermark loading skippable
+- Make DeepGNN snark server temporal loading skippable
 
 ## [0.1.64] - 2024-08-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+- Make DeepGNN snark server watermark loading skippable
+
 ## [0.1.64] - 2024-08-13
 
 ### Added

--- a/src/cc/lib/graph/metadata.cc
+++ b/src/cc/lib/graph/metadata.cc
@@ -62,7 +62,6 @@ Metadata::Metadata(std::filesystem::path path, std::string config_path, bool ski
     // Default meta.json values
     m_node_feature_count = 0;
     m_edge_feature_count = 0;
-    m_watermark = -1;
     m_node_count = meta["node_count"];
     m_edge_count = meta["edge_count"];
     m_node_type_count = meta["node_type_count"];

--- a/src/cc/lib/graph/metadata.cc
+++ b/src/cc/lib/graph/metadata.cc
@@ -17,7 +17,7 @@ namespace snark
 {
 
 Metadata::Metadata(std::filesystem::path path, std::string config_path, bool skip_feature_loading,
-                   std::shared_ptr<Logger> logger)
+                   bool skip_watermark_loading, std::shared_ptr<Logger> logger)
     : m_version(MINIMUM_SUPPORTED_VERSION), m_path(path.string()), m_config_path(config_path), m_watermark(-1)
 {
 
@@ -72,6 +72,12 @@ Metadata::Metadata(std::filesystem::path path, std::string config_path, bool ski
     {
         m_node_feature_count = 0;
         m_edge_feature_count = 0;
+    }
+    // Skip watermark loading if requested. This is useful when the watermark is not needed for the training/inference
+    // job.
+    if (skip_watermark_loading == true)
+    {
+        m_watermark = -1;
     }
 
     m_partition_node_weights =

--- a/src/cc/lib/graph/metadata.cc
+++ b/src/cc/lib/graph/metadata.cc
@@ -18,8 +18,7 @@ namespace snark
 
 Metadata::Metadata(std::filesystem::path path, std::string config_path, bool skip_feature_loading,
                    bool skip_temporal_loading, std::shared_ptr<Logger> logger)
-    : m_version(MINIMUM_SUPPORTED_VERSION), m_path(path.string()), m_config_path(config_path), m_watermark(-1),
-      m_node_feature_count(0), m_edge_feature_count(0)
+    : m_version(MINIMUM_SUPPORTED_VERSION), m_path(path.string()), m_config_path(config_path), m_watermark(-1)
 {
 
     if (!logger)
@@ -60,6 +59,10 @@ Metadata::Metadata(std::filesystem::path path, std::string config_path, bool ski
                           m_version, MINIMUM_SUPPORTED_VERSION);
     }
 
+    // Default meta.json values
+    m_node_feature_count = 0;
+    m_edge_feature_count = 0;
+    m_watermark = -1;
     m_node_count = meta["node_count"];
     m_edge_count = meta["edge_count"];
     m_node_type_count = meta["node_type_count"];

--- a/src/cc/lib/graph/metadata.cc
+++ b/src/cc/lib/graph/metadata.cc
@@ -17,8 +17,9 @@ namespace snark
 {
 
 Metadata::Metadata(std::filesystem::path path, std::string config_path, bool skip_feature_loading,
-                   bool skip_watermark_loading, std::shared_ptr<Logger> logger)
-    : m_version(MINIMUM_SUPPORTED_VERSION), m_path(path.string()), m_config_path(config_path), m_watermark(-1)
+                   bool skip_temporal_loading, std::shared_ptr<Logger> logger)
+    : m_version(MINIMUM_SUPPORTED_VERSION), m_path(path.string()), m_config_path(config_path), m_watermark(-1),
+      m_node_feature_count(0), m_edge_feature_count(0)
 {
 
     if (!logger)
@@ -63,21 +64,19 @@ Metadata::Metadata(std::filesystem::path path, std::string config_path, bool ski
     m_edge_count = meta["edge_count"];
     m_node_type_count = meta["node_type_count"];
     m_edge_type_count = meta["edge_type_count"];
-    m_node_feature_count = meta["node_feature_count"];
-    m_edge_feature_count = meta["edge_feature_count"];
     m_partition_count = meta["partitions"].size();
-    m_watermark = meta["watermark"];
-    // Skip feature loading if requested. This is useful when the feature loading is done in a separate feature store.
-    if (skip_feature_loading == true)
+    // Load features if skip feature loading is not requested.
+    // This is useful when the feature loading is done in a separate feature store.
+    if (skip_feature_loading != true)
     {
-        m_node_feature_count = 0;
-        m_edge_feature_count = 0;
+        m_node_feature_count = meta["node_feature_count"];
+        m_edge_feature_count = meta["edge_feature_count"];
     }
-    // Skip watermark loading if requested. This is useful when the watermark is not needed for the training/inference
-    // job.
-    if (skip_watermark_loading == true)
+    // Load temporal watermark if skip temporal loading is not requested.
+    // This is useful when the temporal watermark is not needed for the training/inference job.
+    if (skip_temporal_loading != true)
     {
-        m_watermark = -1;
+        m_watermark = meta["watermark"];
     }
 
     m_partition_node_weights =

--- a/src/cc/lib/graph/metadata.h
+++ b/src/cc/lib/graph/metadata.h
@@ -19,7 +19,7 @@ struct Metadata
 {
     Metadata() = default;
     explicit Metadata(std::filesystem::path path, std::string config_path = "", bool skip_feature_loading = false,
-                      std::shared_ptr<Logger> logger = nullptr);
+                      bool skip_watermark_loading = false, std::shared_ptr<Logger> logger = nullptr);
     void Write(std::filesystem::path path) const;
 
     // Graph information.

--- a/src/cc/lib/graph/metadata.h
+++ b/src/cc/lib/graph/metadata.h
@@ -19,7 +19,7 @@ struct Metadata
 {
     Metadata() = default;
     explicit Metadata(std::filesystem::path path, std::string config_path = "", bool skip_feature_loading = false,
-                      bool skip_watermark_loading = false, std::shared_ptr<Logger> logger = nullptr);
+                      bool skip_temporal_loading = false, std::shared_ptr<Logger> logger = nullptr);
     void Write(std::filesystem::path path) const;
 
     // Graph information.

--- a/src/cc/lib/py_graph.h
+++ b/src/cc/lib/py_graph.h
@@ -86,7 +86,7 @@ extern "C"
                                            const char *host_name, const char *ssl_key, const char *ssl_cert,
                                            const char *ssl_root, const PyPartitionStorageType storage_type,
                                            const char *config_path, bool skip_feature_loading,
-                                           bool skip_watermark_loading);
+                                           bool skip_temporal_loading);
 
     DEEPGNN_DLL extern int32_t CreateRemoteClient(PyGraph *graph, const char *output_folder, const char **connection,
                                                   size_t connection_count, const char *ssl_cert, size_t num_threads,

--- a/src/cc/lib/py_graph.h
+++ b/src/cc/lib/py_graph.h
@@ -85,7 +85,8 @@ extern "C"
                                            uint32_t *partition_indices, const char **partition_locations,
                                            const char *host_name, const char *ssl_key, const char *ssl_cert,
                                            const char *ssl_root, const PyPartitionStorageType storage_type,
-                                           const char *config_path, bool skip_feature_loading);
+                                           const char *config_path, bool skip_feature_loading,
+                                           bool skip_watermark_loading);
 
     DEEPGNN_DLL extern int32_t CreateRemoteClient(PyGraph *graph, const char *output_folder, const char **connection,
                                                   size_t connection_count, const char *ssl_cert, size_t num_threads,

--- a/src/cc/lib/py_server.cc
+++ b/src/cc/lib/py_server.cc
@@ -32,11 +32,11 @@ std::string safe_convert(const char *buffer)
 int32_t StartServer(PyServer *graph, const char *meta_location, size_t count, uint32_t *partition_indices,
                     const char **partition_locations, const char *host_name, const char *ssl_key, const char *ssl_cert,
                     const char *ssl_root, const PyPartitionStorageType storage_type_, const char *config_path,
-                    bool skip_feature_loading, bool skip_watermark_loading)
+                    bool skip_feature_loading, bool skip_temporal_loading)
 {
     snark::PartitionStorageType storage_type = static_cast<snark::PartitionStorageType>(storage_type_);
     snark::Metadata metadata(safe_convert(meta_location), safe_convert(config_path), skip_feature_loading,
-                             skip_watermark_loading);
+                             skip_temporal_loading);
     std::vector<std::string> partition_paths;
     partition_paths.reserve(count);
     for (size_t i = 0; i < count; ++i)

--- a/src/cc/lib/py_server.cc
+++ b/src/cc/lib/py_server.cc
@@ -32,10 +32,11 @@ std::string safe_convert(const char *buffer)
 int32_t StartServer(PyServer *graph, const char *meta_location, size_t count, uint32_t *partition_indices,
                     const char **partition_locations, const char *host_name, const char *ssl_key, const char *ssl_cert,
                     const char *ssl_root, const PyPartitionStorageType storage_type_, const char *config_path,
-                    bool skip_feature_loading)
+                    bool skip_feature_loading, bool skip_watermark_loading)
 {
     snark::PartitionStorageType storage_type = static_cast<snark::PartitionStorageType>(storage_type_);
-    snark::Metadata metadata(safe_convert(meta_location), safe_convert(config_path), skip_feature_loading);
+    snark::Metadata metadata(safe_convert(meta_location), safe_convert(config_path), skip_feature_loading,
+                             skip_watermark_loading);
     std::vector<std::string> partition_paths;
     partition_paths.reserve(count);
     for (size_t i = 0; i < count; ++i)

--- a/src/cc/tests/graph_test.cc
+++ b/src/cc/tests/graph_test.cc
@@ -583,7 +583,7 @@ TEST_P(StorageTypeGraphTest, NodeFeaturesMultipleNodesWithDifferentFeatureTimest
               std::vector<float>({1.f, 2.f, 3.f, 13.f, 14.f, 0.f}));
 }
 
-TEST_P(StorageTypeGraphTest, NodeFeaturesMultipleNodesWithoutTimestamps)
+TEST_P(StorageTypeGraphTest, NodeFeaturesMultipleNodesWithoutLoadingEdgeTimestamps)
 {
     TestGraph::MemoryGraph m;
     std::vector<std::vector<float>> f1 = {TestGraph::serialize_temporal_features(
@@ -607,7 +607,8 @@ TEST_P(StorageTypeGraphTest, NodeFeaturesMultipleNodesWithoutTimestamps)
     g.GetNodeFeature(std::span(nodes), std::span(ts), std::span(features), std::span(large_output));
     std::span large_res(reinterpret_cast<float *>(large_output.data()), large_output.size() / 4);
     EXPECT_EQ(std::vector<float>(std::begin(large_res), std::end(large_res)),
-              std::vector<float>({1.f, 2.f, 3.f, 0.f, 0.f, 0.f}));
+              std::vector<float>({1.f, 2.f, 3.f, 13.f, 14.f, 0.f}));
+    EXPECT_EQ(metadata.m_watermark, -1);
 }
 
 TEST_P(StorageTypeGraphTest, NodeFeaturesSameNodeFeatureDifferentPartitionsWithoutDeleteTimestamp)

--- a/src/python/deepgnn/graph_engine/snark/distributed.py
+++ b/src/python/deepgnn/graph_engine/snark/distributed.py
@@ -72,6 +72,7 @@ class Server:
         config_path: str = "",
         stream: bool = False,
         skip_feature_loading: bool = False,
+        skip_watermark_loading: bool = False,
     ):
         """Init snark server."""
         temp_dir = tempfile.TemporaryDirectory()
@@ -106,6 +107,7 @@ class Server:
             config_path,
             stream,  # type: ignore
             skip_feature_loading,
+            skip_watermark_loading,
         )
 
     def reset(self):

--- a/src/python/deepgnn/graph_engine/snark/distributed.py
+++ b/src/python/deepgnn/graph_engine/snark/distributed.py
@@ -72,7 +72,7 @@ class Server:
         config_path: str = "",
         stream: bool = False,
         skip_feature_loading: bool = False,
-        skip_watermark_loading: bool = False,
+        skip_temporal_loading: bool = False,
     ):
         """Init snark server."""
         temp_dir = tempfile.TemporaryDirectory()
@@ -107,7 +107,7 @@ class Server:
             config_path,
             stream,  # type: ignore
             skip_feature_loading,
-            skip_watermark_loading,
+            skip_temporal_loading,
         )
 
     def reset(self):

--- a/src/python/deepgnn/graph_engine/snark/server.py
+++ b/src/python/deepgnn/graph_engine/snark/server.py
@@ -49,6 +49,7 @@ class Server:
         config_path: str = "",
         stream: bool = False,
         skip_feature_loading: bool = False,
+        skip_watermark_loading: bool = False,
     ):
         """Create server and start it.
 
@@ -65,6 +66,7 @@ class Server:
             stream (bool, default=False): If remote path is given: by default, download files first then load,
                 if stream = True and libhdfs present, stream data directly to memory.
             skip_feature_loading (bool, default=False): Skip loading node and edge features into DeepGNN server.
+            skip_watermark_loading (bool, default=False): Skip loading node and edge watermarks into DeepGNN server.
         """
         if storage_type == PartitionStorageType.disk and stream:
             raise ValueError(
@@ -115,6 +117,7 @@ class Server:
             c_int32,
             c_char_p,
             c_bool,
+            c_bool,
         ]
 
         self.lib.StartServer.errcheck = _ErrCallback("start server")  # type: ignore
@@ -150,6 +153,7 @@ class Server:
             c_int32(storage_type),
             c_char_p(bytes(config_path, "utf-8")),
             skip_feature_loading,
+            skip_watermark_loading,
         )
 
     def reset(self):
@@ -226,6 +230,12 @@ if __name__ == "__main__":
         default=False,
         help="If True, skip loading node and edge features into DeepGNN server.",
     )
+    parser.add_argument(
+        "--skip_watermark_loading",
+        action="store_true",
+        default=False,
+        help="If True, skip loading node and edge watermarks into DeepGNN server.",
+    )
 
     args, _ = parser.parse_known_args()
     if args.server_group is not None:
@@ -248,6 +258,7 @@ if __name__ == "__main__":
         config_path=args.config_path,
         stream=args.stream,
         skip_feature_loading=args.skip_feature_loading,
+        skip_watermark_loading=args.skip_watermark_loading,
     )
     logger.info("Server started...")
     try:

--- a/src/python/deepgnn/graph_engine/snark/server.py
+++ b/src/python/deepgnn/graph_engine/snark/server.py
@@ -49,7 +49,7 @@ class Server:
         config_path: str = "",
         stream: bool = False,
         skip_feature_loading: bool = False,
-        skip_watermark_loading: bool = False,
+        skip_temporal_loading: bool = False,
     ):
         """Create server and start it.
 
@@ -66,7 +66,7 @@ class Server:
             stream (bool, default=False): If remote path is given: by default, download files first then load,
                 if stream = True and libhdfs present, stream data directly to memory.
             skip_feature_loading (bool, default=False): Skip loading node and edge features into DeepGNN server.
-            skip_watermark_loading (bool, default=False): Skip loading node and edge watermarks into DeepGNN server.
+            skip_temporal_loading (bool, default=False): Skip loading node and edge watermarks into DeepGNN server.
         """
         if storage_type == PartitionStorageType.disk and stream:
             raise ValueError(
@@ -153,7 +153,7 @@ class Server:
             c_int32(storage_type),
             c_char_p(bytes(config_path, "utf-8")),
             skip_feature_loading,
-            skip_watermark_loading,
+            skip_temporal_loading,
         )
 
     def reset(self):
@@ -231,10 +231,10 @@ if __name__ == "__main__":
         help="If True, skip loading node and edge features into DeepGNN server.",
     )
     parser.add_argument(
-        "--skip_watermark_loading",
+        "--skip_temporal_loading",
         action="store_true",
         default=False,
-        help="If True, skip loading node and edge watermarks into DeepGNN server.",
+        help="If True, skip loading node and edge temporal watermarks into DeepGNN server.",
     )
 
     args, _ = parser.parse_known_args()
@@ -258,7 +258,7 @@ if __name__ == "__main__":
         config_path=args.config_path,
         stream=args.stream,
         skip_feature_loading=args.skip_feature_loading,
-        skip_watermark_loading=args.skip_watermark_loading,
+        skip_temporal_loading=args.skip_temporal_loading,
     )
     logger.info("Server started...")
     try:

--- a/src/python/deepgnn/graph_engine/snark/tests/hdfs_test.py
+++ b/src/python/deepgnn/graph_engine/snark/tests/hdfs_test.py
@@ -114,7 +114,7 @@ def test_hdfs_remote_skip_feature_loading(hdfs_data):
         config_path="",
         stream=True,
         skip_feature_loading=True,
-        skip_watermark_loading=True,
+        skip_temporal_loading=True,
     )
     cl = client.DistributedGraph(address)
 

--- a/src/python/deepgnn/graph_engine/snark/tests/hdfs_test.py
+++ b/src/python/deepgnn/graph_engine/snark/tests/hdfs_test.py
@@ -114,6 +114,7 @@ def test_hdfs_remote_skip_feature_loading(hdfs_data):
         config_path="",
         stream=True,
         skip_feature_loading=True,
+        skip_watermark_loading=True,
     )
     cl = client.DistributedGraph(address)
 


### PR DESCRIPTION
We propose adding a flag to the DeepGNN Snark Server that allows us to opt out of loading watermark without modifying the meta.json. Our dataset watermarks constitute more than 30% of our data which could waste a lot of GE memory resources. For models that don't require the watermark, we want to configure the GE to avoid loading the unused watermark. This will enable faster loading times and save resources for hosting GEs.

- [x] Forked repo is synced with upstream -> github shows no code delta outside of the desired.
    https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork
- [ ] Tests are passing? https://github.com/microsoft/DeepGNN/blob/main/CONTRIBUTING.md#run-tests
- [x] Changelog and documentation updated.
- [x] PR is labeled using the label menu on the right side.

Previous Behavior
----------------
GE have to load all the watermarks unless manually change the meta.json that's shared with other developers/teams.

New Behavior
----------------
Users can pick whether to load features or watermark based on their model training settings.